### PR TITLE
feat: new plugins definition syntax

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -6,6 +6,7 @@ module.exports = {
     '^.+\\.ts$': ['ts-jest', { useESM: true }],
   },
   moduleNameMapper: {
+    '^magefront$': '<rootDir>/packages/magefront/src/main.ts',
     '^magefront-plugin-less$': '<rootDir>/packages/plugin-less/src/plugin.ts',
     '^magefront-plugin-requirejs-config$': '<rootDir>/packages/plugin-requirejs-config/src/plugin.ts',
     '^magefront-plugin-js-translation$': '<rootDir>/packages/plugin-js-translation/src/plugin.ts',

--- a/packages/magefront/src/actions/build.ts
+++ b/packages/magefront/src/actions/build.ts
@@ -28,7 +28,7 @@ export const build: Action = async (context) => {
 
   for (const plugin of buildConfig.plugins) {
     try {
-      await plugin(pluginContext)
+      await plugin.build(pluginContext)
     } catch (e) {
       // TODO: Should be critical error
       logger.error(e)

--- a/packages/magefront/src/config.ts
+++ b/packages/magefront/src/config.ts
@@ -1,6 +1,7 @@
 import memo from 'memoizee'
 import path from 'node:path'
-import type { BuildConfig, MagefrontOptions, MagentoContext, MagentoTheme, Plugin, Preset } from '../types/magefront'
+import type { BuildConfig, MagefrontOptions, MagentoContext, MagentoTheme } from '../types/magefront'
+import { transformPluginDefinition, transformPresetDefinition } from './config/resolver'
 import { getThemes } from './magento/theme'
 
 /** Get the build configuration for the given options. */
@@ -53,59 +54,3 @@ export const getBuildConfig = memo(async (opts: MagefrontOptions, context: Magen
 
   return { tmp, dest, plugins }
 })
-
-/** Transform the plugin to a function if it is not already. If passed a string, import the plugin and return the default export. */
-async function transformPluginDefinition(definition: any): Promise<Plugin> {
-  if (typeof definition === 'function') {
-    return definition
-  }
-
-  if (typeof definition === 'string') {
-    const { default: pluginModule } = await import(resolveModuleNameFromPluginStr(definition))
-    return pluginModule()
-  }
-
-  if (Array.isArray(definition)) {
-    const [pluginName, options] = definition
-    const { default: pluginModule } = await import(resolveModuleNameFromPluginStr(pluginName))
-    return pluginModule(options)
-  }
-
-  throw new Error(`Invalid plugin type: ${typeof definition}`)
-}
-
-/** Return the full module name from the given plugin string. */
-function resolveModuleNameFromPluginStr(str: string): string {
-  if (str.startsWith('magefront-plugin-')) {
-    return str
-  }
-  return `magefront-plugin-${str}`
-}
-
-/** Transform the preset to a function if it is not already. If passed a string, import the preset and return the default export. */
-async function transformPresetDefinition(definition: any): Promise<Preset> {
-  if (typeof definition === 'string') {
-    const { default: presetModule } = await import(resolveModuleNameFromPresetStr(definition))
-    return presetModule()
-  }
-
-  if (Array.isArray(definition)) {
-    const [presetName, options] = definition
-    const { default: presetModule } = await import(resolveModuleNameFromPresetStr(presetName))
-    return presetModule(options)
-  }
-
-  if (typeof definition === 'object') {
-    return definition
-  }
-
-  throw new Error(`Invalid plugin type: ${typeof definition}`)
-}
-
-/** Return the full module name from the given preset string. */
-function resolveModuleNameFromPresetStr(str: string): string {
-  if (str.startsWith('magefront-preset-')) {
-    return str
-  }
-  return `magefront-preset-${str}`
-}

--- a/packages/magefront/src/config/resolver.ts
+++ b/packages/magefront/src/config/resolver.ts
@@ -1,0 +1,63 @@
+import defaultPreset from 'magefront-preset-default'
+import type { Plugin, Preset } from '../../types/magefront'
+
+/** Return a map of all the built-in plugins (from the default preset). */
+function getBuiltInPluginModules(): Map<string, Plugin> {
+  const plugins = defaultPreset().plugins || []
+  const map = new Map<string, Plugin>()
+  plugins.forEach((plugin) => map.set('magefront-plugin-' + plugin.name, plugin))
+  return map
+}
+
+/** Import the plugin and return the default export. If the plugin is not found, fallback to the built-in plugins from the default preset. */
+async function importPluginWithFallback(identifier: string, options?: any): Promise<Plugin> {
+  try {
+    const { default: pluginModule } = await import(identifier)
+    return pluginModule(options)
+  } catch (e) {
+    const builtin = getBuiltInPluginModules()
+    if (builtin.has(identifier)) {
+      return builtin.get(identifier)!
+    } else {
+      throw e
+    }
+  }
+}
+
+/** Transform the plugin to a function if it is not already. If passed a string, import the plugin and return the default export. */
+export async function transformPluginDefinition(definition: any): Promise<Plugin> {
+  if (typeof definition === 'object' && typeof definition.build === 'function') {
+    return definition
+  }
+
+  if (typeof definition === 'string') {
+    return await importPluginWithFallback(definition)
+  }
+
+  if (Array.isArray(definition)) {
+    const [pluginName, options] = definition
+    return await importPluginWithFallback(pluginName, options)
+  }
+
+  throw new Error(`Invalid plugin type: ${typeof definition}`)
+}
+
+/** Transform the preset to a function if it is not already. If passed a string, import the preset and return the default export. */
+export async function transformPresetDefinition(definition: any): Promise<Preset> {
+  if (typeof definition === 'string') {
+    const { default: presetModule } = await import(definition)
+    return presetModule()
+  }
+
+  if (Array.isArray(definition)) {
+    const [presetName, options] = definition
+    const { default: presetModule } = await import(presetName)
+    return presetModule(options)
+  }
+
+  if (typeof definition === 'object') {
+    return definition
+  }
+
+  throw new Error(`Invalid plugin type: ${typeof definition}`)
+}

--- a/packages/magefront/types/magefront.d.ts
+++ b/packages/magefront/types/magefront.d.ts
@@ -43,8 +43,18 @@ declare namespace magefront {
   }
 
   export interface Plugin {
+    /** The name of the plugin. */
     name: string
+
+    /** The build function that is called when the plugin is executed. */
     build: (context: PluginContext) => MaybePromise<void>
+
+    watcherConfig?: {
+      /** The files to reload if the right counterpart matches a changed file. If the key is '*', the whole page is reloaded. */
+      reload?: {
+        [file: string]: string | RegExp | Array<string | RegExp>
+      }
+    }
   }
 
   // The preset configuration object. Contains already defined plugins (because we cannot resolve them at the module level).

--- a/packages/magefront/types/magefront.d.ts
+++ b/packages/magefront/types/magefront.d.ts
@@ -42,7 +42,10 @@ declare namespace magefront {
     logger: Logger
   }
 
-  export type Plugin = (context: PluginContext) => Promise<void>
+  export interface Plugin {
+    name: string
+    build: (context: PluginContext) => MaybePromise<void>
+  }
 
   // The preset configuration object. Contains already defined plugins (because we cannot resolve them at the module level).
   export type Preset = {

--- a/packages/plugin-babel/src/plugin.ts
+++ b/packages/plugin-babel/src/plugin.ts
@@ -17,17 +17,20 @@ export default (options?: Options): Plugin => {
     throw new Error('The `src` option is required')
   }
 
-  return async (context) => {
-    const files = await glob(src, {
-      ignore: ignore ?? [],
-      cwd: context.src,
-    })
-
-    await Promise.all(
-      files.map((file) => {
-        const filePath = path.join(context.src, file)
-        return babel.transformAsync(filePath, compilerOptions)
+  return {
+    name: 'babel',
+    async build(context) {
+      const files = await glob(src, {
+        ignore: ignore ?? [],
+        cwd: context.src,
       })
-    )
+
+      await Promise.all(
+        files.map((file) => {
+          const filePath = path.join(context.src, file)
+          return babel.transformAsync(filePath, compilerOptions)
+        })
+      )
+    },
   }
 }

--- a/packages/plugin-concat/src/plugin.ts
+++ b/packages/plugin-concat/src/plugin.ts
@@ -14,35 +14,38 @@ export interface Options {
 export default (options?: Options): Plugin => {
   const { src, ignore, dest, remove = true } = { ...options }
 
-  return async (context) => {
-    if (!src) {
-      throw new Error('Missing "src" option')
-    }
+  return {
+    name: 'concat',
+    async build(context) {
+      if (!src) {
+        throw new Error('Missing "src" option')
+      }
 
-    if (!dest) {
-      throw new Error('Missing "dest" option')
-    }
+      if (!dest) {
+        throw new Error('Missing "dest" option')
+      }
 
-    const files = await glob(src, { ignore, cwd: context.src })
+      const files = await glob(src, { ignore, cwd: context.src })
 
-    const packed = await Promise.all(
-      files.map((file: string) => {
-        const filePath = path.join(context.src, file)
-        return fs.readFile(filePath, 'utf8')
-      })
-    )
-
-    // Delete the original files
-    if (remove ?? true) {
-      await Promise.all(
+      const packed = await Promise.all(
         files.map((file: string) => {
           const filePath = path.join(context.src, file)
-          return fs.unlink(filePath)
+          return fs.readFile(filePath, 'utf8')
         })
       )
-    }
 
-    // Write the merged file (after deleting the original files)
-    await fs.writeFile(path.join(context.src, dest), packed.join('\n'), 'utf8')
+      // Delete the original files
+      if (remove ?? true) {
+        await Promise.all(
+          files.map((file: string) => {
+            const filePath = path.join(context.src, file)
+            return fs.unlink(filePath)
+          })
+        )
+      }
+
+      // Write the merged file (after deleting the original files)
+      await fs.writeFile(path.join(context.src, dest), packed.join('\n'), 'utf8')
+    },
   }
 }

--- a/packages/plugin-cssnano/src/plugin.ts
+++ b/packages/plugin-cssnano/src/plugin.ts
@@ -11,14 +11,17 @@ export interface Options extends PostcssOptions {
 export default (options?: Options): Plugin => {
   const { src, ignore, preset, plugins } = { ...options }
 
-  return postcss({
-    src,
-    ignore,
-    plugins: [
-      cssnano({
-        preset: preset ?? 'default',
-        plugins,
-      }),
-    ],
-  })
+  return {
+    ...postcss({
+      src,
+      ignore,
+      plugins: [
+        cssnano({
+          preset: preset ?? 'default',
+          plugins,
+        }),
+      ],
+    }),
+    name: 'cssnano',
+  }
 }

--- a/packages/plugin-js-bundle/src/plugin.ts
+++ b/packages/plugin-js-bundle/src/plugin.ts
@@ -5,9 +5,9 @@ export interface Options {
 }
 
 /** Merge JS files into multiple chunks. */
-export default (options?: Options): Plugin => {
-  // TODO: Implement this plugin using rollup?
-  return async (context) => {
+export default (options?: Options): Plugin => ({
+  name: 'js-bundle',
+  async build(context) {
     throw new Error('Not implemented yet')
-  }
-}
+  },
+})

--- a/packages/plugin-js-translation/src/plugin.ts
+++ b/packages/plugin-js-translation/src/plugin.ts
@@ -4,8 +4,9 @@ import fs from 'node:fs'
 import path from 'node:path'
 
 /** Generates a `js-translation.json` file for the current locale. */
-export default (): Plugin => {
-  return async (context) => {
+export default (): Plugin => ({
+  name: 'js-translation',
+  async build(context) {
     const files = []
 
     const { locale, moduleList, languageList, cwd } = context
@@ -80,5 +81,5 @@ export default (): Plugin => {
       parser.on('error', reject)
       parser.on('finish', resolve)
     })
-  }
-}
+  },
+})

--- a/packages/plugin-less/src/plugin.ts
+++ b/packages/plugin-less/src/plugin.ts
@@ -69,6 +69,11 @@ export default (options?: Options): Plugin => {
         })
       )
     },
+    watcherConfig: {
+      reload: {
+        '*.css': /\.less$/,
+      },
+    },
   }
 }
 

--- a/packages/plugin-less/src/plugin.ts
+++ b/packages/plugin-less/src/plugin.ts
@@ -22,52 +22,53 @@ export default (options?: Options): Plugin => {
   const plugins = options?.plugins ?? []
   const magentoImport = options?.magentoImport ?? true
 
-  return async (context) => {
-    // Add the default magento import plugin
-    // Necessary to resolve the "//@magento_import" statements in the core styles
-    if (magentoImport) {
-      plugins.unshift(magentoImportPreprocessor(context.modules))
-    }
+  return {
+    name: 'less',
+    async build(context) {
+      // Add the default magento import plugin
+      // Necessary to resolve the "//@magento_import" statements in the core styles
+      if (magentoImport) {
+        plugins.unshift(magentoImportPreprocessor(context.modules))
+      }
 
-    const files = await glob(src ?? '**/!(_)*.less', {
-      ignore,
-      cwd: context.src,
-    })
-
-    await Promise.all(
-      files.map(async (file: string) => {
-        const filePath = path.join(context.src, file)
-        const fileContent = await fs.readFile(filePath, 'utf8')
-
-        const output = await less
-          .render(
-            fileContent.toString(),
-            {
-              sourceMap: sourcemaps,
-              plugins,
-              ...compilerOptions,
-              filename: path.resolve(filePath),
-            },
-            false
-          )
-          .catch((error: any) => {
-            // TODO: Throw error and catch it with logger
-            console.error(error)
-          })
-          .then((output: any) => output)
-
-        const cssFilePath = filePath.replace(/\.less$/, '.css')
-
-        if (output.css) {
-          await fs.writeFile(cssFilePath, output.css, 'utf8')
-        }
-
-        // TODO: Render the map alongside the CSS file
-        if (output.map) {
-          await fs.writeFile(`${cssFilePath}.map`, output.map, 'utf8')
-        }
+      const files = await glob(src ?? '**/!(_)*.less', {
+        ignore,
+        cwd: context.src,
       })
-    )
+
+      await Promise.all(
+        files.map(async (file: string) => {
+          const filePath = path.join(context.src, file)
+          const fileContent = await fs.readFile(filePath, 'utf8')
+
+          let output: Less.RenderOutput
+
+          const renderOptions = {
+            sourceMap: sourcemaps,
+            plugins,
+            ...compilerOptions,
+            filename: path.resolve(filePath),
+          }
+
+          try {
+            output = await less.render(fileContent, renderOptions, false)
+          } catch (e) {
+            context.logger.error(e)
+            return
+          }
+
+          const cssFilePath = filePath.replace(/\.less$/, '.css')
+
+          if (output.css) {
+            await fs.writeFile(cssFilePath, output.css, 'utf8')
+          }
+
+          if (output.map) {
+            await fs.writeFile(`${cssFilePath}.map`, output.map, 'utf8')
+          }
+        })
+      )
+    },
   }
 }
 

--- a/packages/plugin-pngquant/src/plugin.ts
+++ b/packages/plugin-pngquant/src/plugin.ts
@@ -17,22 +17,25 @@ export default (options?: Options): Plugin => {
     new PngQuant([...args, '--force', filename])
   }
 
-  return async (context) => {
-    const files = await glob(src ?? '**/*.png', {
-      ignore,
-      cwd: context.src,
-    })
-
-    await Promise.all(
-      files.map(async (file) => {
-        const filePath = path.join(context.src, file)
-
-        try {
-          compress(filePath)
-        } catch (e) {
-          console.error('PNGQUANT error', e)
-        }
+  return {
+    name: 'pngquant',
+    async build(context) {
+      const files = await glob(src ?? '**/*.png', {
+        ignore,
+        cwd: context.src,
       })
-    )
+
+      await Promise.all(
+        files.map(async (file) => {
+          const filePath = path.join(context.src, file)
+
+          try {
+            compress(filePath)
+          } catch (e) {
+            context.logger.error('PNGQUANT error', e)
+          }
+        })
+      )
+    },
   }
 }

--- a/packages/plugin-react/src/plugin.ts
+++ b/packages/plugin-react/src/plugin.ts
@@ -18,9 +18,12 @@ export default (options?: Options): Plugin => {
     ],
   }
 
-  return babel({
-    src,
-    ignore,
-    compilerOptions: compilerOptions ?? babelReactPreset,
-  })
+  return {
+    ...babel({
+      src,
+      ignore,
+      compilerOptions: compilerOptions ?? babelReactPreset,
+    }),
+    name: 'react',
+  }
 }

--- a/packages/plugin-requirejs-config/src/plugin.ts
+++ b/packages/plugin-requirejs-config/src/plugin.ts
@@ -4,8 +4,9 @@ import fs from 'node:fs'
 import path from 'node:path'
 
 /** Merge all the requirejs-config files into one. */
-export default (): Plugin => {
-  return async (context) => {
+export default (): Plugin => ({
+  name: 'requirejs-config',
+  async build(context) {
     const files: string[] = []
     const { themeList, themeDependencyTree } = context
     const moduleList = context.moduleList.filter((mod) => mod.enabled && mod.src)
@@ -49,5 +50,5 @@ export default (): Plugin => {
     // Output the final requirejs-config.js file, so it can be deployed
     const file = path.join(context.src, 'requirejs-config.js')
     await fs.promises.writeFile(file, `(function(require){\n${packed.join('')}})(require);`)
-  }
-}
+  },
+})

--- a/packages/plugin-sass/src/plugin.ts
+++ b/packages/plugin-sass/src/plugin.ts
@@ -19,25 +19,28 @@ export interface Options {
 export default (options: Options = {}): Plugin => {
   const { src, ignore, sourcemaps, compilerOptions } = { ...options }
 
-  return async (context) => {
-    const files = await glob(src ?? '**/!(_)*.scss', {
-      ignore: ignore ?? [],
-      cwd: context.src,
-    })
-
-    await Promise.all(
-      files.map(async (file) => {
-        const filePath = path.join(context.src, file)
-        const output = await compileAsync(filePath, compilerOptions)
-
-        const cssFilePath = filePath.replace(/\.scss$/, '.css')
-        await fs.writeFile(cssFilePath, output.css, 'utf8')
-
-        // TODO: The map is always null?
-        if (sourcemaps && output.sourceMap) {
-          await fs.writeFile(`${cssFilePath}.map`, JSON.stringify(output.sourceMap), 'utf8')
-        }
+  return {
+    name: 'sass',
+    async build(context) {
+      const files = await glob(src ?? '**/!(_)*.scss', {
+        ignore: ignore ?? [],
+        cwd: context.src,
       })
-    )
+
+      await Promise.all(
+        files.map(async (file) => {
+          const filePath = path.join(context.src, file)
+          const output = await compileAsync(filePath, compilerOptions)
+
+          const cssFilePath = filePath.replace(/\.scss$/, '.css')
+          await fs.writeFile(cssFilePath, output.css, 'utf8')
+
+          // TODO: The map is always null?
+          if (sourcemaps && output.sourceMap) {
+            await fs.writeFile(`${cssFilePath}.map`, JSON.stringify(output.sourceMap), 'utf8')
+          }
+        })
+      )
+    },
   }
 }

--- a/packages/plugin-stylus/src/plugin.ts
+++ b/packages/plugin-stylus/src/plugin.ts
@@ -15,37 +15,40 @@ export interface Options {
 export default (options?: Options): Plugin => {
   const { src, ignore, sourcemaps, compilerOptions } = { ...options }
 
-  return async (context) => {
-    const files = await glob(src || '**/!(_)*.styl', {
-      ignore: ignore ?? [],
-      cwd: context.src,
-    })
-
-    await Promise.all(
-      files.map(async (file) => {
-        const filePath = path.join(context.src, file)
-        const fileContent = await fs.promises.readFile(filePath, 'utf8')
-
-        const style = stylus(fileContent.toString(), {
-          // @ts-ignore TODO: the option is not recognized
-          sourcemap: sourcemaps,
-          ...compilerOptions,
-          filename: path.resolve(filePath),
-        })
-
-        style.render((err, css) => {
-          if (err) {
-            console.error(err)
-          } else {
-            const cssFilePath = filePath.replace(/\.styl$/, '.css')
-            fs.writeFileSync(cssFilePath, css, 'utf8')
-
-            if (sourcemaps) {
-              // fs.writeFileSync(`${cssFilePath}.map`, JSON.stringify(style.sourcemap), 'utf8')
-            }
-          }
-        })
+  return {
+    name: 'stylus',
+    async build(context) {
+      const files = await glob(src || '**/!(_)*.styl', {
+        ignore: ignore ?? [],
+        cwd: context.src,
       })
-    )
+
+      await Promise.all(
+        files.map(async (file) => {
+          const filePath = path.join(context.src, file)
+          const fileContent = await fs.promises.readFile(filePath, 'utf8')
+
+          const style = stylus(fileContent.toString(), {
+            // @ts-ignore TODO: the option is not recognized
+            sourcemap: sourcemaps,
+            ...compilerOptions,
+            filename: path.resolve(filePath),
+          })
+
+          style.render((err, css) => {
+            if (err) {
+              console.error(err)
+            } else {
+              const cssFilePath = filePath.replace(/\.styl$/, '.css')
+              fs.writeFileSync(cssFilePath, css, 'utf8')
+
+              if (sourcemaps) {
+                // fs.writeFileSync(`${cssFilePath}.map`, JSON.stringify(style.sourcemap), 'utf8')
+              }
+            }
+          })
+        })
+      )
+    },
   }
 }

--- a/packages/plugin-svelte/src/plugin.ts
+++ b/packages/plugin-svelte/src/plugin.ts
@@ -15,20 +15,23 @@ export interface Options {
 export default (options?: Options): Plugin => {
   const { src, ignore, compilerOptions } = { ...options }
 
-  return async (context) => {
-    const files = await glob(src ?? '**/*.svelte', {
-      ignore: ignore ?? [],
-      cwd: context.src,
-    })
-
-    await Promise.all(
-      files.map(async (file) => {
-        const filePath = path.join(context.src, file)
-        const fileContent = await fs.promises.readFile(filePath)
-        const output = compile(fileContent.toString(), compilerOptions ?? {})
-
-        return fs.promises.writeFile(filePath.replace(/\.svelte$/, '.js'), output.js.code)
+  return {
+    name: 'svelte',
+    async build(context) {
+      const files = await glob(src ?? '**/*.svelte', {
+        ignore: ignore ?? [],
+        cwd: context.src,
       })
-    )
+
+      await Promise.all(
+        files.map(async (file) => {
+          const filePath = path.join(context.src, file)
+          const fileContent = await fs.promises.readFile(filePath)
+          const output = compile(fileContent.toString(), compilerOptions ?? {})
+
+          return fs.promises.writeFile(filePath.replace(/\.svelte$/, '.js'), output.js.code)
+        })
+      )
+    },
   }
 }

--- a/packages/plugin-svgo/src/plugin.ts
+++ b/packages/plugin-svgo/src/plugin.ts
@@ -14,24 +14,27 @@ export interface Options {
 export default (options?: Options): Plugin => {
   const { src, ignore, optimizeOptions } = { ...options }
 
-  return async (context) => {
-    const files = await glob(src ?? '**/*.svg', {
-      ignore,
-      cwd: context.src,
-    })
-
-    await Promise.all(
-      files.map(async (file) => {
-        const filePath = path.join(context.src, file)
-        const fileContent = await fs.readFile(filePath)
-        const result = svgo.optimize(fileContent.toString(), optimizeOptions)
-
-        if ('data' in result) {
-          await fs.writeFile(filePath, result.data)
-        } else {
-          console.error('SVGO error', result)
-        }
+  return {
+    name: 'svgo',
+    async build(context) {
+      const files = await glob(src ?? '**/*.svg', {
+        ignore,
+        cwd: context.src,
       })
-    )
+
+      await Promise.all(
+        files.map(async (file) => {
+          const filePath = path.join(context.src, file)
+          const fileContent = await fs.readFile(filePath)
+          const result = svgo.optimize(fileContent.toString(), optimizeOptions)
+
+          if ('data' in result) {
+            await fs.writeFile(filePath, result.data)
+          } else {
+            console.error('SVGO error', result)
+          }
+        })
+      )
+    },
   }
 }

--- a/packages/plugin-tailwindcss/src/plugin.ts
+++ b/packages/plugin-tailwindcss/src/plugin.ts
@@ -14,26 +14,29 @@ export default (options?: Options): Plugin => {
     throw new Error('Missing required option: src')
   }
 
-  return async (context) => {
-    // TODO: Target the phtml files (from the module sources, might target overridden files)
-    // TODO: Target the layout files (from the module sources, might target overridden files)
-    const modulePaths = context.modules.map((mod) => path.join(context.src, mod, '/**/*.html'))
+  return {
+    name: 'tailwindcss',
+    async build(context) {
+      // TODO: Target the phtml files (from the module sources, might target overridden files)
+      // TODO: Target the layout files (from the module sources, might target overridden files)
+      const modulePaths = context.modules.map((mod) => path.join(context.src, mod, '/**/*.html'))
 
-    // TODO: Let the user target its content files
-    const content = [
-      // prettier-ignore
-      ...modulePaths,
-    ]
+      // TODO: Let the user target its content files
+      const content = [
+        // prettier-ignore
+        ...modulePaths,
+      ]
 
-    const plugin = postcss({
-      src,
-      ignore,
-      plugins: [
-        // @ts-ignore
-        tailwind({ ...config, content }),
-      ],
-    })
+      const plugin = postcss({
+        src,
+        ignore,
+        plugins: [
+          // @ts-ignore
+          tailwind({ ...config, content }),
+        ],
+      })
 
-    await plugin(context)
+      await plugin.build(context)
+    },
   }
 }

--- a/packages/plugin-terser/src/plugin.ts
+++ b/packages/plugin-terser/src/plugin.ts
@@ -14,18 +14,21 @@ export interface Options {
 export default (options?: Options): Plugin => {
   const { src, ignore, terserOptions } = { ...options }
 
-  return async (context) => {
-    const files = await glob(src ?? '**/*.js', { ignore, cwd: context.src })
+  return {
+    name: 'terser',
+    async build(context) {
+      const files = await glob(src ?? '**/*.js', { ignore, cwd: context.src })
 
-    await Promise.all(
-      files.map(async (file: string) => {
-        const filePath = path.join(context.src, file)
-        const fileContent = await fs.readFile(filePath)
-        const { code } = await minify(fileContent.toString(), terserOptions || {})
-        if (code) {
-          return fs.writeFile(filePath, code)
-        }
-      })
-    )
+      await Promise.all(
+        files.map(async (file: string) => {
+          const filePath = path.join(context.src, file)
+          const fileContent = await fs.readFile(filePath)
+          const { code } = await minify(fileContent.toString(), terserOptions || {})
+          if (code) {
+            return fs.writeFile(filePath, code)
+          }
+        })
+      )
+    },
   }
 }

--- a/packages/plugin-typescript/src/plugin.ts
+++ b/packages/plugin-typescript/src/plugin.ts
@@ -14,20 +14,23 @@ export interface Options {
 export default (options?: Options): Plugin => {
   const { src, ignore, compilerOptions } = { ...options }
 
-  return async (context) => {
-    const files = await glob(src ?? '**/*.ts', {
-      ignore: ignore ?? ['**/node_modules/**', '**/*.d.ts'],
-      cwd: context.src,
-    })
-
-    await Promise.all(
-      files.map(async (file) => {
-        const filePath = path.join(context.src, file)
-        const fileContent = await fs.readFile(filePath)
-        const output = typescript.transpile(fileContent.toString(), compilerOptions ?? {})
-
-        return fs.writeFile(filePath.replace(/\.ts$/, '.js'), output)
+  return {
+    name: 'typescript',
+    async build(context) {
+      const files = await glob(src ?? '**/*.ts', {
+        ignore: ignore ?? ['**/node_modules/**', '**/*.d.ts'],
+        cwd: context.src,
       })
-    )
+
+      await Promise.all(
+        files.map(async (file) => {
+          const filePath = path.join(context.src, file)
+          const fileContent = await fs.readFile(filePath)
+          const output = typescript.transpile(fileContent.toString(), compilerOptions ?? {})
+
+          return fs.writeFile(filePath.replace(/\.ts$/, '.js'), output)
+        })
+      )
+    },
   }
 }


### PR DESCRIPTION
plugins should return a more complex interface

```ts
export interface Plugin {
  /** The name of the plugin. */
  name: string

  /** The build function that is called when the plugin is executed. */
  build: (context: PluginContext) => MaybePromise<void>

  watcherConfig?: {
    /** The files to reload if the right counterpart matches a changed file. If the key is '*', the whole page is reloaded. */
    reload?: {
      [file: string]: string | RegExp | Array<string | RegExp>
    }
  }
}
```

- #33