### PR TITLE
fix paths and peers

### DIFF
--- a/.changeset/sharp-cheetahs-tease.md
+++ b/.changeset/sharp-cheetahs-tease.md
@@ -1,0 +1,16 @@
+---
+'magefront-plugin-requirejs-config': minor
+'magefront-plugin-js-translation': minor
+'magefront-plugin-typescript': minor
+'magefront-plugin-imagemin': minor
+'magefront-preset-optimize': minor
+'magefront-plugin-postcss': minor
+'magefront-preset-default': minor
+'magefront-plugin-stylus': minor
+'magefront-plugin-svelte': minor
+'magefront-plugin-babel': minor
+'magefront-plugin-less': minor
+'magefront-plugin-sass': minor
+---
+
+Move dependency to peer so the version of the 3rd party package is not fixed

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -26,6 +26,8 @@ module.exports = {
     ecmaVersion: 'latest',
     sourceType: 'module',
   },
-  plugins: ['@typescript-eslint'],
-  rules: {},
+  plugins: ['import', '@typescript-eslint'],
+  rules: {
+    'import/extensions': ['error', 'always', { ignorePackages: true }],
+  },
 }

--- a/docs/plugins/babel.md
+++ b/docs/plugins/babel.md
@@ -8,8 +8,10 @@ Transpile JS files with [Babel](https://babeljs.io/).
 
 ## Install
 
+Install the plugin and its dependencies:
+
 ```shell
-npm i magefront-plugin-babel --save-dev
+npm i magefront-plugin-babel @babel/core --save-dev
 ```
 
 ## Usage

--- a/docs/plugins/imagemin.md
+++ b/docs/plugins/imagemin.md
@@ -8,8 +8,10 @@ A plugin to optimize your images.
 
 ## Install
 
+Install the plugin and its dependencies:
+
 ```shell
-npm i magefront-plugin-imagemin --save-dev
+npm i imagemin magefront-plugin-imagemin --save-dev
 ```
 
 ## Usage

--- a/docs/plugins/less.md
+++ b/docs/plugins/less.md
@@ -8,9 +8,13 @@ Transforms Less files into CSS files.
 
 ## Install
 
+Install the plugin and its dependencies:
+
 ```shell
-npm i magefront-plugin-less --save-dev
+npm i less@2 magefront-plugin-less --save-dev
 ```
+
+> See the [compatibility](#compatibility) section for more info.
 
 ## Usage
 
@@ -36,18 +40,13 @@ The source files to minify. Default is `**/!(_)*.less`.
 
 A list of paths to ignore.
 
-### `compiler`
-
-The less compiler to use.<br>
-The default is set on **less:2.7** for [compatibility](#compatibility) with the legacy **Magento 2** themes.
-
 ### `sourcemaps`
 
 Enable sourcemaps. Default is `false`.
 
 ### `plugins`
 
-A list of plugins to use. See [less docs](http://lesscss.org/usage/#plugins) for more info.<br>
+A list of plugins to use. See [less docs](http://lesscss.org/usage/#plugins) for more info.
 
 ### `magentoImport`
 
@@ -55,23 +54,16 @@ Enable the [magento import](#magento-imports) feature. Default is `true`.
 
 ### `compilerOptions`
 
-Options to pass to the less compiler. See [less docs](http://lesscss.org/usage/#programmatic-usage) for more info.
+Options to pass to the **Less** compiler. See [less docs](http://lesscss.org/usage/#programmatic-usage) for more info.
 
 ## Compatibility
 
-The default LESS version is `2.7.3`, so it can be compatible with the actual **Magento 2** themes, without any configuration.
+The preferred **Less** version is `2.7.3`, so it can be compatible with the actual **Magento 2** themes, without any configuration.
 
-A `compiler` option is available if you need the latest LESS features:
+If you need the latest **Less** features, you can install the latest version of the compiler and pass it to the plugin:
 
-```js
-import less from 'magefront-plugin-less'
-import v4 from 'less'
-
-export default {
-    plugins: [
-        less({ compiler: v4 })
-    ]
-}
+```shell
+npm i less@latest --save-dev
 ```
 
 ## Magento imports
@@ -86,7 +78,7 @@ You can find this kind of imports into the `styles-m.less` file, for example:
 
 This will be transformed into:
 
-```css
+```less
 /* ... */
 @import '../Magento_AdvancedSearch/css/source/_module.less';
 @import '../Magento_Bundle/css/source/_module.less';

--- a/docs/plugins/less.md
+++ b/docs/plugins/less.md
@@ -11,7 +11,7 @@ Transforms Less files into CSS files.
 Install the plugin and its dependencies:
 
 ```shell
-npm i less@2 magefront-plugin-less --save-dev
+npm i less@3 magefront-plugin-less --save-dev
 ```
 
 > See the [compatibility](#compatibility) section for more info.
@@ -58,7 +58,7 @@ Options to pass to the **Less** compiler. See [less docs](http://lesscss.org/usa
 
 ## Compatibility
 
-The preferred **Less** version is `2.7.3`, so it can be compatible with the actual **Magento 2** themes, without any configuration.
+The preferred **Less** version is `3.x`, so it can be compatible with the actual **Magento 2** themes, without any configuration.
 
 If you need the latest **Less** features, you can install the latest version of the compiler and pass it to the plugin:
 

--- a/docs/plugins/postcss.md
+++ b/docs/plugins/postcss.md
@@ -8,8 +8,10 @@ PostCSS plugin for **magefront**.
 
 ## Install
 
+Install the plugin and its dependencies:
+
 ```shell
-npm i magefront-plugin-postcss --save-dev
+npm i postcss magefront-plugin-postcss --save-dev
 ```
 
 ## Usage

--- a/docs/plugins/sass.md
+++ b/docs/plugins/sass.md
@@ -8,8 +8,10 @@ Transforms SCSS files into CSS files.
 
 ## Install
 
+Install the plugin and its dependencies:
+
 ```shell
-npm i magefront-plugin-sass --save-dev
+npm i sass magefront-plugin-sass --save-dev
 ```
 
 ## Usage

--- a/docs/plugins/stylus.md
+++ b/docs/plugins/stylus.md
@@ -8,8 +8,10 @@ Transforms STYL files into CSS files.
 
 ## Install
 
+Install the plugin and its dependencies:
+
 ```shell
-npm i magefront-plugin-stylus --save-dev
+npm i stylus magefront-plugin-stylus --save-dev
 ```
 
 ## Usage

--- a/docs/plugins/svelte.md
+++ b/docs/plugins/svelte.md
@@ -8,9 +8,10 @@ Compile *.svelte files into JS files.
 
 ## Install
 
+Install the plugin and its dependencies:
 
 ```shell
-npm i magefront-plugin-svelte --save-dev
+npm i svelte magefront-plugin-svelte --save-dev
 ```
 
 ## Usage

--- a/docs/plugins/typescript.md
+++ b/docs/plugins/typescript.md
@@ -8,8 +8,10 @@ Transforms *.ts files into JS files.
 
 ## Install
 
+Install the plugin and its dependencies:
+
 ```shell
-npm i magefront-plugin-typescript --save-dev
+npm i typescript magefront-plugin-typescript --save-dev
 ```
 
 ## Usage

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@ubermanu/prettier-config": "^3.2.0",
     "dotenv": "^16.3.1",
     "eslint": "^8.49.0",
+    "eslint-plugin-import": "^2.28.1",
     "jest": "^29.7.0",
     "prettier": "^3.0.3",
     "prettier-plugin-svelte": "^3.0.3",

--- a/packages/magefront/src/actions/build.js
+++ b/packages/magefront/src/actions/build.js
@@ -1,5 +1,5 @@
 import path from 'node:path'
-import { getThemeDependencyTree } from '../magento/theme'
+import { getThemeDependencyTree } from '../magento/theme.js'
 
 /**
  * Build the theme. If a configuration file is found, it will be used.

--- a/packages/magefront/src/actions/context.js
+++ b/packages/magefront/src/actions/context.js
@@ -1,9 +1,9 @@
-import { getBuildConfig } from '../config'
-import { createLogger } from '../logger'
-import { createMagentoContext } from '../magento/context'
-import { getLanguages } from '../magento/language'
-import { getModules } from '../magento/module'
-import { getThemes } from '../magento/theme'
+import { getBuildConfig } from '../config.js'
+import { createLogger } from '../logger.js'
+import { createMagentoContext } from '../magento/context.js'
+import { getLanguages } from '../magento/language.js'
+import { getModules } from '../magento/module.js'
+import { getThemes } from '../magento/theme.js'
 
 /**
  * Creates an ActionContext object to be passed to the build process.

--- a/packages/magefront/src/actions/inheritance.js
+++ b/packages/magefront/src/actions/inheritance.js
@@ -1,7 +1,7 @@
 import glob from 'fast-glob'
 import fs from 'fs-extra'
 import path from 'node:path'
-import { getThemeDependencyTree } from '../magento/theme'
+import { getThemeDependencyTree } from '../magento/theme.js'
 
 /**
  * Gather all the theme files and copy them to the temporary directory. When this is done, the `build` task should be run afterwards.

--- a/packages/magefront/src/actions/list.js
+++ b/packages/magefront/src/actions/list.js
@@ -1,6 +1,6 @@
 import Table from 'cli-table'
 import console from 'node:console'
-import { getThemes } from '../magento/theme'
+import { getThemes } from '../magento/theme.js'
 
 /**
  * List all the themes.

--- a/packages/magefront/src/actions/watch.js
+++ b/packages/magefront/src/actions/watch.js
@@ -2,10 +2,10 @@ import chokidar from 'chokidar'
 import path from 'node:path'
 import { performance } from 'node:perf_hooks'
 import prettyMilliseconds from 'pretty-ms'
-import { instance } from './browser-sync'
-import { build } from './build'
-import { deploy } from './deploy'
-import { inheritance } from './inheritance'
+import { instance } from './browser-sync.js'
+import { build } from './build.js'
+import { deploy } from './deploy.js'
+import { inheritance } from './inheritance.js'
 
 /**
  * Watch the source files of a theme, and rebuild on change.

--- a/packages/magefront/src/cli.js
+++ b/packages/magefront/src/cli.js
@@ -5,14 +5,14 @@ import process from 'node:process'
 import sade from 'sade'
 import winston from 'winston'
 import pkg from '../package.json'
-import { browserSync } from './actions/browser-sync'
-import { createActionContext } from './actions/context'
-import { list } from './actions/list'
-import { watch } from './actions/watch'
-import { createLogger } from './logger'
-import { magefront } from './magefront'
-import { createMagentoContext } from './magento/context'
-import * as u from './utils'
+import { browserSync } from './actions/browser-sync.js'
+import { createActionContext } from './actions/context.js'
+import { list } from './actions/list.js'
+import { watch } from './actions/watch.js'
+import { createLogger } from './logger.js'
+import { magefront } from './magefront.js'
+import { createMagentoContext } from './magento/context.js'
+import * as u from './utils.js'
 
 const program = sade('magefront', true)
 
@@ -71,7 +71,7 @@ program.action(async (opts) => {
   }
 
   if (config) {
-    const filename = config.length > 0 ? config : 'config.{js,mjs,cjs}'
+    const filename = config.length > 0 ? config : 'magefront.config.{js,mjs,cjs}'
     const files = await glob(filename, { onlyFiles: true, cwd: magento.rootPath })
 
     if (files.length === 0) {

--- a/packages/magefront/src/config.js
+++ b/packages/magefront/src/config.js
@@ -1,6 +1,6 @@
 import memo from 'memoizee'
 import path from 'node:path'
-import { getThemes } from './magento/theme'
+import { getThemes } from './magento/theme.js'
 
 /**
  * Get the build configuration for the given options.

--- a/packages/magefront/src/magefront.js
+++ b/packages/magefront/src/magefront.js
@@ -1,11 +1,11 @@
 import k from 'kleur'
 import { performance } from 'node:perf_hooks'
 import prettyMilliseconds from 'pretty-ms'
-import { build } from './actions/build'
-import { clean } from './actions/clean'
-import { createActionContext } from './actions/context'
-import { deploy } from './actions/deploy'
-import { inheritance } from './actions/inheritance'
+import { build } from './actions/build.js'
+import { clean } from './actions/clean.js'
+import { createActionContext } from './actions/context.js'
+import { deploy } from './actions/deploy.js'
+import { inheritance } from './actions/inheritance.js'
 
 /**
  * Builds a Magento 2 theme.

--- a/packages/magefront/src/magento/context.js
+++ b/packages/magefront/src/magento/context.js
@@ -1,4 +1,4 @@
-import { getPackages } from './composer'
+import { getPackages } from './composer.js'
 
 /**
  * Create a Magento context.

--- a/packages/magefront/src/magento/language.js
+++ b/packages/magefront/src/magento/language.js
@@ -1,7 +1,7 @@
 import memo from 'memoizee'
 import fs from 'node:fs'
 import path from 'node:path'
-import { getRegistrations } from './composer'
+import { getRegistrations } from './composer.js'
 
 /**
  * Get all the languages loaded from the `composer.lock` file.
@@ -23,6 +23,11 @@ export const getLanguages = memo((context) => {
       const src = path.join('vendor', pkg.name, path.dirname(registration))
       const name = pkg.name
       const code = getCodeFromLanguageXml(path.join(rootPath, src, 'language.xml'))
+
+      if (!code) {
+        // TODO: logger.warn(`Language code not found in ${src}/language.xml`)
+        return
+      }
 
       list[name] = {
         name,

--- a/packages/magefront/src/magento/module.js
+++ b/packages/magefront/src/magento/module.js
@@ -2,7 +2,7 @@ import glob from 'fast-glob'
 import memo from 'memoizee'
 import fs from 'node:fs'
 import path from 'node:path'
-import { getRegistrations } from './composer'
+import { getRegistrations } from './composer.js'
 
 /**
  * Read the `config.php` file and return the modules list. Resolve the modules paths from `app/code` then from the `vendor` directory.

--- a/packages/magefront/src/magento/theme.js
+++ b/packages/magefront/src/magento/theme.js
@@ -2,7 +2,7 @@ import glob from 'fast-glob'
 import memo from 'memoizee'
 import fs from 'node:fs'
 import path from 'node:path'
-import { getRegistrations } from './composer'
+import { getRegistrations } from './composer.js'
 
 /**
  * Crawl the Magento project source code and return a list of all the themes.

--- a/packages/magefront/src/main.js
+++ b/packages/magefront/src/main.js
@@ -1,4 +1,4 @@
-export { magefront } from './magefront'
+export { magefront } from './magefront.js'
 
 /**
  * Auxiliary function for defining the configuration object.

--- a/packages/magefront/tests/config.test.js
+++ b/packages/magefront/tests/config.test.js
@@ -1,4 +1,4 @@
-import { testActionContext } from './helpers'
+import { testActionContext } from './helpers.js'
 
 test('Empty configuration returns the default plugins', async () => {
   const context = await testActionContext()

--- a/packages/magefront/tests/helpers.js
+++ b/packages/magefront/tests/helpers.js
@@ -1,5 +1,5 @@
 import process from 'node:process'
-import { createActionContext } from '../src/actions/context'
+import { createActionContext } from '../src/actions/context.js'
 
 export const rootPath = process.env.MAGEFRONT_TEST_MAGENTO_ROOT ?? ''
 

--- a/packages/magefront/tests/magefront.test.js
+++ b/packages/magefront/tests/magefront.test.js
@@ -1,7 +1,7 @@
 import fs from 'node:fs'
 import path from 'node:path'
-import { magefront } from '../src/magefront'
-import { rootPath } from './helpers'
+import { magefront } from '../src/magefront.js'
+import { rootPath } from './helpers.js'
 
 test('Can be called programmatically', async () => {
   await magefront({ theme: 'Magento/blank', magento: { rootPath } })

--- a/packages/magefront/tests/magento.test.js
+++ b/packages/magefront/tests/magento.test.js
@@ -1,4 +1,4 @@
-import { testActionContext } from './helpers'
+import { testActionContext } from './helpers.js'
 
 test('Get all the modules from Magento source code', async () => {
   const context = await testActionContext()

--- a/packages/magefront/tests/theme-adminhtml-backend.test.js
+++ b/packages/magefront/tests/theme-adminhtml-backend.test.js
@@ -1,10 +1,10 @@
 import fs from 'node:fs'
 import path from 'node:path'
-import { build } from '../src/actions/build'
-import { clean } from '../src/actions/clean'
-import { deploy } from '../src/actions/deploy'
-import { inheritance } from '../src/actions/inheritance'
-import { testActionContext } from './helpers'
+import { build } from '../src/actions/build.js'
+import { clean } from '../src/actions/clean.js'
+import { deploy } from '../src/actions/deploy.js'
+import { inheritance } from '../src/actions/inheritance.js'
+import { testActionContext } from './helpers.js'
 
 describe('Build and deploy the Magento/backend theme', () => {
   /** @type {import('types').ActionContext} */

--- a/packages/magefront/tests/theme-frontend-blank.test.js
+++ b/packages/magefront/tests/theme-frontend-blank.test.js
@@ -1,10 +1,10 @@
 import fs from 'node:fs'
 import path from 'node:path'
-import { build } from '../src/actions/build'
-import { clean } from '../src/actions/clean'
-import { deploy } from '../src/actions/deploy'
-import { inheritance } from '../src/actions/inheritance'
-import { testActionContext } from './helpers'
+import { build } from '../src/actions/build.js'
+import { clean } from '../src/actions/clean.js'
+import { deploy } from '../src/actions/deploy.js'
+import { inheritance } from '../src/actions/inheritance.js'
+import { testActionContext } from './helpers.js'
 
 describe('Build and deploy the Magento/blank theme', () => {
   /** @type {import('types').ActionContext} */

--- a/packages/magefront/tests/theme-frontend-luma.test.js
+++ b/packages/magefront/tests/theme-frontend-luma.test.js
@@ -1,10 +1,10 @@
 import fs from 'node:fs'
 import path from 'node:path'
-import { build } from '../src/actions/build'
-import { clean } from '../src/actions/clean'
-import { deploy } from '../src/actions/deploy'
-import { inheritance } from '../src/actions/inheritance'
-import { testActionContext } from './helpers'
+import { build } from '../src/actions/build.js'
+import { clean } from '../src/actions/clean.js'
+import { deploy } from '../src/actions/deploy.js'
+import { inheritance } from '../src/actions/inheritance.js'
+import { testActionContext } from './helpers.js'
 
 describe('Build and deploy the Magento/luma theme', () => {
   /** @type {import('types').ActionContext} */

--- a/packages/plugin-babel/README.md
+++ b/packages/plugin-babel/README.md
@@ -4,7 +4,7 @@ Transpile JS files with [Babel](https://babeljs.io/).
 
 ## Install
 
-    npm i magefront-plugin-babel
+    npm i magefront-plugin-babel @babel/core @babel/preset-env
 
 ## Usage
 
@@ -12,7 +12,12 @@ Transpile JS files with [Babel](https://babeljs.io/).
 import babel from 'magefront-plugin-babel'
 
 export default {
-  plugins: [babel({ src: 'js/source/**/*.js' })],
+  plugins: [
+    babel({
+      src: 'js/source/**/*.js',
+      compilerOptions: { presets: ['@babel/preset-env'] },
+    }),
+  ],
 }
 ```
 

--- a/packages/plugin-babel/package.json
+++ b/packages/plugin-babel/package.json
@@ -27,13 +27,11 @@
     "src"
   ],
   "dependencies": {
-    "@babel/core": "~7.22.20",
-    "fast-glob": "^3.3.1"
-  },
-  "devDependencies": {
+    "fast-glob": "^3.3.1",
     "@types/babel__core": "~7.20.2"
   },
   "peerDependencies": {
-    "magefront": "workspace:^"
+    "magefront": "workspace:^",
+    "@babel/core": "~7.22.20"
   }
 }

--- a/packages/plugin-imagemin/README.md
+++ b/packages/plugin-imagemin/README.md
@@ -4,7 +4,7 @@ Optimize images with [imagemin](https://github.com/imagemin/imagemin).
 
 ## Install
 
-    npm i magefront-plugin-imagemin
+    npm i imagemin magefront-plugin-imagemin
 
 ## Usage
 

--- a/packages/plugin-imagemin/package.json
+++ b/packages/plugin-imagemin/package.json
@@ -29,13 +29,11 @@
     "src"
   ],
   "dependencies": {
-    "fast-glob": "^3.3.1",
-    "imagemin": "^8.0.1"
-  },
-  "devDependencies": {
-    "@types/imagemin": "^8.0.1"
+    "@types/imagemin": "^8.0.1",
+    "fast-glob": "^3.3.1"
   },
   "peerDependencies": {
+    "imagemin": "^8.0.1",
     "magefront": "workspace:^"
   }
 }

--- a/packages/plugin-js-translation/tests/plugin.test.js
+++ b/packages/plugin-js-translation/tests/plugin.test.js
@@ -2,7 +2,7 @@ import { magefront } from 'magefront'
 import fs from 'node:fs'
 import path from 'node:path'
 import process from 'node:process'
-import jsTranslation from '../src/plugin'
+import jsTranslation from '../src/plugin.js'
 
 const rootPath = process.env.MAGEFRONT_TEST_MAGENTO_ROOT
 

--- a/packages/plugin-less/README.md
+++ b/packages/plugin-less/README.md
@@ -4,7 +4,7 @@ Transforms LESS files into CSS files.
 
 ## Install
 
-    npm i magefront-plugin-less
+    npm i less magefront-plugin-less
 
 ## Usage
 

--- a/packages/plugin-less/package.json
+++ b/packages/plugin-less/package.json
@@ -30,6 +30,9 @@
     "@types/less": "^3.0.4",
     "fast-glob": "^3.3.1"
   },
+  "devDependencies": {
+    "less": "2.7.3"
+  },
   "peerDependencies": {
     "less": ">=2.7.3",
     "magefront": "workspace:^"

--- a/packages/plugin-less/package.json
+++ b/packages/plugin-less/package.json
@@ -27,13 +27,11 @@
     "src"
   ],
   "dependencies": {
-    "fast-glob": "^3.3.1",
-    "less": "2.7"
-  },
-  "devDependencies": {
-    "@types/less": "^3.0.4"
+    "@types/less": "^3.0.4",
+    "fast-glob": "^3.3.1"
   },
   "peerDependencies": {
+    "less": ">=2.7.3",
     "magefront": "workspace:^"
   }
 }

--- a/packages/plugin-less/package.json
+++ b/packages/plugin-less/package.json
@@ -31,10 +31,10 @@
     "fast-glob": "^3.3.1"
   },
   "devDependencies": {
-    "less": "2.7.3"
+    "less": "3.13.1"
   },
   "peerDependencies": {
-    "less": ">=2.7.3",
+    "less": ">=3.13.1",
     "magefront": "workspace:^"
   }
 }

--- a/packages/plugin-less/src/plugin.d.ts
+++ b/packages/plugin-less/src/plugin.d.ts
@@ -8,7 +8,6 @@ interface Options {
   src?: string | string[]
   ignore?: Pattern[]
   sourcemaps?: boolean
-  compiler?: LessStatic
   magentoImport?: boolean
   plugins?: Less.Plugin[]
   compilerOptions?: Less.Options

--- a/packages/plugin-less/src/plugin.js
+++ b/packages/plugin-less/src/plugin.js
@@ -1,8 +1,8 @@
 import glob from 'fast-glob'
-import less27 from 'less'
+import less from 'less'
 import fs from 'node:fs/promises'
 import path from 'node:path'
-import magentoImportPreprocessor from './magento-import-preprocessor'
+import magentoImportPreprocessor from './magento-import-preprocessor.js'
 
 /**
  * For all the `less` files in the `css` directory, compile them to CSS.
@@ -14,7 +14,7 @@ export default (options) => ({
   name: 'less',
 
   async build(context) {
-    const { src, ignore, compiler, sourcemaps, compilerOptions } = { ...options }
+    const { src, ignore, sourcemaps, compilerOptions } = { ...options }
     const plugins = options?.plugins ?? []
     const magentoImport = options?.magentoImport ?? true
 
@@ -29,19 +29,21 @@ export default (options) => ({
       cwd: context.src,
     })
 
+    /**
+     * @type {{
+     *   render: (input: string, options: Less.Options, callback: boolean | Function) => Promise<Less.RenderOutput>
+     * }}
+     */
+    const _less = less
+
+    context.logger.debug(`Using Less v${less.version.toString().replace(/,/g, '.')}`)
+
     await Promise.all(
       files.map(async (file) => {
         const filePath = path.join(context.src, file)
         const fileContent = await fs.readFile(filePath, 'utf8')
 
-        /**
-         * @type {{
-         *   render: (input: string, options: Less.Options, callback: boolean | Function) => Promise<Less.RenderOutput>
-         * }}
-         */
-        const less = compiler ?? less27
-
-        const output = await less.render(
+        const output = await _less.render(
           fileContent.toString(),
           {
             sourceMap: {

--- a/packages/plugin-less/tests/magento-import-preprocessor.test.js
+++ b/packages/plugin-less/tests/magento-import-preprocessor.test.js
@@ -1,4 +1,4 @@
-import { preProcessor } from '../src/magento-import-preprocessor'
+import { preProcessor } from '../src/magento-import-preprocessor.js'
 
 test('Replace the `@magento_import` statement with the correct one', () => {
   const pp = new preProcessor(['Magento_Catalog'])

--- a/packages/plugin-less/tests/plugin.test.js
+++ b/packages/plugin-less/tests/plugin.test.js
@@ -2,7 +2,7 @@ import { magefront } from 'magefront'
 import fs from 'node:fs'
 import path from 'node:path'
 import process from 'node:process'
-import less from '../src/plugin'
+import less from '../src/plugin.js'
 
 const rootPath = process.env.MAGEFRONT_TEST_MAGENTO_ROOT
 

--- a/packages/plugin-postcss/README.md
+++ b/packages/plugin-postcss/README.md
@@ -4,7 +4,7 @@ PostCSS plugin for **magefront**.
 
 ## Install
 
-    npm i magefront-plugin-postcss
+    npm i postcss magefront-plugin-postcss
 
 ## Usage
 

--- a/packages/plugin-postcss/package.json
+++ b/packages/plugin-postcss/package.json
@@ -27,10 +27,10 @@
     "src"
   ],
   "dependencies": {
-    "fast-glob": "^3.3.1",
-    "postcss": "^8.4.29"
+    "fast-glob": "^3.3.1"
   },
   "peerDependencies": {
-    "magefront": "workspace:^"
+    "magefront": "workspace:^",
+    "postcss": "^8.4.29"
   }
 }

--- a/packages/plugin-requirejs-config/tests/plugin.test.js
+++ b/packages/plugin-requirejs-config/tests/plugin.test.js
@@ -2,7 +2,7 @@ import { magefront } from 'magefront'
 import fs from 'node:fs'
 import path from 'node:path'
 import process from 'node:process'
-import requireJsConfig from '../src/plugin'
+import requireJsConfig from '../src/plugin.js'
 
 const rootPath = process.env.MAGEFRONT_TEST_MAGENTO_ROOT
 

--- a/packages/plugin-sass/README.md
+++ b/packages/plugin-sass/README.md
@@ -4,7 +4,7 @@ Transforms SCSS files into CSS files.
 
 ## Install
 
-    npm i magefront-plugin-sass
+    npm i sass magefront-plugin-sass
 
 ## Usage
 

--- a/packages/plugin-sass/package.json
+++ b/packages/plugin-sass/package.json
@@ -28,10 +28,10 @@
     "src"
   ],
   "dependencies": {
-    "fast-glob": "^3.3.1",
-    "sass": "^1.67.0"
+    "fast-glob": "^3.3.1"
   },
   "peerDependencies": {
-    "magefront": "workspace:^"
+    "magefront": "workspace:^",
+    "sass": "^1.67.0"
   }
 }

--- a/packages/plugin-stylus/README.md
+++ b/packages/plugin-stylus/README.md
@@ -4,7 +4,7 @@ Transforms STYL files into CSS files.
 
 ## Install
 
-    npm i magefront-plugin-stylus
+    npm i stylus magefront-plugin-stylus
 
 ## Usage
 

--- a/packages/plugin-stylus/package.json
+++ b/packages/plugin-stylus/package.json
@@ -27,13 +27,11 @@
     "src"
   ],
   "dependencies": {
-    "fast-glob": "^3.3.1",
-    "stylus": "^0.60.0"
-  },
-  "devDependencies": {
-    "@types/stylus": "^0.48.39"
+    "@types/stylus": "^0.48.39",
+    "fast-glob": "^3.3.1"
   },
   "peerDependencies": {
-    "magefront": "workspace:^"
+    "magefront": "workspace:^",
+    "stylus": "^0.60.0"
   }
 }

--- a/packages/plugin-svelte/README.md
+++ b/packages/plugin-svelte/README.md
@@ -4,7 +4,7 @@ Transforms \*.svelte files into JS files.
 
 ## Install
 
-    npm i magefront-plugin-svelte
+    npm i svelte magefront-plugin-svelte
 
 ## Usage
 

--- a/packages/plugin-svelte/package.json
+++ b/packages/plugin-svelte/package.json
@@ -27,10 +27,10 @@
     "src"
   ],
   "dependencies": {
-    "fast-glob": "^3.3.1",
-    "svelte": "~4.2.0"
+    "fast-glob": "^3.3.1"
   },
   "peerDependencies": {
-    "magefront": "workspace:^"
+    "magefront": "workspace:^",
+    "svelte": "^4.2.0"
   }
 }

--- a/packages/plugin-terser/README.md
+++ b/packages/plugin-terser/README.md
@@ -4,7 +4,7 @@ Minify JS files with [terser](https://terser.org/).
 
 ## Install
 
-    npm i terser magefront-plugin-terser
+    npm i magefront-plugin-terser
 
 ## Usage
 

--- a/packages/plugin-terser/README.md
+++ b/packages/plugin-terser/README.md
@@ -4,7 +4,7 @@ Minify JS files with [terser](https://terser.org/).
 
 ## Install
 
-    npm i magefront-plugin-terser
+    npm i terser magefront-plugin-terser
 
 ## Usage
 

--- a/packages/plugin-terser/package.json
+++ b/packages/plugin-terser/package.json
@@ -27,10 +27,10 @@
     "src"
   ],
   "dependencies": {
-    "fast-glob": "^3.3.1",
-    "terser": "^5.19.4"
+    "fast-glob": "^3.3.1"
   },
   "peerDependencies": {
-    "magefront": "workspace:^"
+    "magefront": "workspace:^",
+    "terser": "^5.19.4"
   }
 }

--- a/packages/plugin-terser/package.json
+++ b/packages/plugin-terser/package.json
@@ -27,10 +27,10 @@
     "src"
   ],
   "dependencies": {
-    "fast-glob": "^3.3.1"
+    "fast-glob": "^3.3.1",
+    "terser": "^5.19.4"
   },
   "peerDependencies": {
-    "magefront": "workspace:^",
-    "terser": "^5.19.4"
+    "magefront": "workspace:^"
   }
 }

--- a/packages/plugin-typescript/README.md
+++ b/packages/plugin-typescript/README.md
@@ -4,7 +4,7 @@ Transforms \*.ts files into JS files.
 
 ## Install
 
-    npm i magefront-plugin-typescript
+    npm i typescript magefront-plugin-typescript
 
 ## Usage
 

--- a/packages/plugin-typescript/package.json
+++ b/packages/plugin-typescript/package.json
@@ -27,10 +27,10 @@
     "src"
   ],
   "dependencies": {
-    "fast-glob": "^3.3.1",
-    "typescript": "^5.2.2"
+    "fast-glob": "^3.3.1"
   },
   "peerDependencies": {
-    "magefront": "workspace:^"
+    "magefront": "workspace:^",
+    "typescript": "^5.2.2"
   }
 }

--- a/packages/preset-default/README.md
+++ b/packages/preset-default/README.md
@@ -2,7 +2,7 @@
 
 Regroup a collection of plugins to build a Magento 2 theme.
 
-- less
+- less (v2.7.3)
 - requirejs-config
 - js-translation
 

--- a/packages/preset-default/README.md
+++ b/packages/preset-default/README.md
@@ -2,7 +2,7 @@
 
 Regroup a collection of plugins to build a Magento 2 theme.
 
-- less (v2.7.3)
+- less (v3.13.1)
 - requirejs-config
 - js-translation
 

--- a/packages/preset-default/package.json
+++ b/packages/preset-default/package.json
@@ -29,11 +29,14 @@
   "dependencies": {
     "cssnano": "^6.0.1",
     "cssnano-preset-default": "^6.0.1",
+    "less": "2.7.3",
     "magefront-plugin-js-translation": "workspace:^",
     "magefront-plugin-less": "workspace:^",
     "magefront-plugin-postcss": "workspace:^",
     "magefront-plugin-requirejs-config": "workspace:^",
-    "magefront-plugin-terser": "workspace:^"
+    "magefront-plugin-terser": "workspace:^",
+    "postcss": "^8.4.30",
+    "terser": "^5.19.4"
   },
   "peerDependencies": {
     "magefront": "workspace:^"

--- a/packages/preset-default/package.json
+++ b/packages/preset-default/package.json
@@ -5,7 +5,8 @@
     "magefront",
     "magento",
     "theme",
-    "preset"
+    "preset",
+    "default"
   ],
   "repository": {
     "type": "git",

--- a/packages/preset-default/package.json
+++ b/packages/preset-default/package.json
@@ -30,7 +30,7 @@
   "dependencies": {
     "cssnano": "^6.0.1",
     "cssnano-preset-default": "^6.0.1",
-    "less": "2.7.3",
+    "less": "3.13.1",
     "magefront-plugin-js-translation": "workspace:^",
     "magefront-plugin-less": "workspace:^",
     "magefront-plugin-postcss": "workspace:^",

--- a/packages/preset-default/package.json
+++ b/packages/preset-default/package.json
@@ -36,8 +36,7 @@
     "magefront-plugin-postcss": "workspace:^",
     "magefront-plugin-requirejs-config": "workspace:^",
     "magefront-plugin-terser": "workspace:^",
-    "postcss": "^8.4.30",
-    "terser": "^5.19.4"
+    "postcss": "^8.4.30"
   },
   "peerDependencies": {
     "magefront": "workspace:^"

--- a/packages/preset-optimize/package.json
+++ b/packages/preset-optimize/package.json
@@ -29,6 +29,7 @@
     "src"
   ],
   "dependencies": {
+    "imagemin": "^8.0.1",
     "imagemin-gifsicle": "^7.0.0",
     "imagemin-jpegtran": "^7.0.0",
     "imagemin-pngquant": "^9.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -37,6 +37,9 @@ importers:
       eslint:
         specifier: ^8.49.0
         version: 8.49.0
+      eslint-plugin-import:
+        specifier: ^2.28.1
+        version: 2.28.1(@typescript-eslint/parser@6.7.0)(eslint@8.49.0)
       jest:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@20.6.2)
@@ -110,16 +113,15 @@ importers:
       '@babel/core':
         specifier: ~7.22.20
         version: 7.22.20
+      '@types/babel__core':
+        specifier: ~7.20.2
+        version: 7.20.2
       fast-glob:
         specifier: ^3.3.1
         version: 3.3.1
       magefront:
         specifier: workspace:^
         version: link:../magefront
-    devDependencies:
-      '@types/babel__core':
-        specifier: ~7.20.2
-        version: 7.20.2
 
   packages/plugin-concat:
     dependencies:
@@ -132,6 +134,9 @@ importers:
 
   packages/plugin-imagemin:
     dependencies:
+      '@types/imagemin':
+        specifier: ^8.0.1
+        version: 8.0.1
       fast-glob:
         specifier: ^3.3.1
         version: 3.3.1
@@ -141,10 +146,6 @@ importers:
       magefront:
         specifier: workspace:^
         version: link:../magefront
-    devDependencies:
-      '@types/imagemin':
-        specifier: ^8.0.1
-        version: 8.0.1
 
   packages/plugin-js-bundle:
     dependencies:
@@ -163,19 +164,18 @@ importers:
 
   packages/plugin-less:
     dependencies:
+      '@types/less':
+        specifier: ^3.0.4
+        version: 3.0.4
       fast-glob:
         specifier: ^3.3.1
         version: 3.3.1
       less:
-        specifier: '2.7'
+        specifier: '>=2.7.3'
         version: 2.7.3
       magefront:
         specifier: workspace:^
         version: link:../magefront
-    devDependencies:
-      '@types/less':
-        specifier: ^3.0.4
-        version: 3.0.4
 
   packages/plugin-postcss:
     dependencies:
@@ -212,6 +212,9 @@ importers:
 
   packages/plugin-stylus:
     dependencies:
+      '@types/stylus':
+        specifier: ^0.48.39
+        version: 0.48.39
       fast-glob:
         specifier: ^3.3.1
         version: 3.3.1
@@ -221,10 +224,6 @@ importers:
       stylus:
         specifier: ^0.60.0
         version: 0.60.0
-    devDependencies:
-      '@types/stylus':
-        specifier: ^0.48.39
-        version: 0.48.39
 
   packages/plugin-svelte:
     dependencies:
@@ -266,10 +265,13 @@ importers:
     dependencies:
       cssnano:
         specifier: ^6.0.1
-        version: 6.0.1(postcss@8.4.29)
+        version: 6.0.1(postcss@8.4.30)
       cssnano-preset-default:
         specifier: ^6.0.1
-        version: 6.0.1(postcss@8.4.29)
+        version: 6.0.1(postcss@8.4.30)
+      less:
+        specifier: 2.7.3
+        version: 2.7.3
       magefront:
         specifier: workspace:^
         version: link:../magefront
@@ -288,9 +290,18 @@ importers:
       magefront-plugin-terser:
         specifier: workspace:^
         version: link:../plugin-terser
+      postcss:
+        specifier: ^8.4.30
+        version: 8.4.30
+      terser:
+        specifier: ^5.19.4
+        version: 5.19.4
 
   packages/preset-optimize:
     dependencies:
+      imagemin:
+        specifier: ^8.0.1
+        version: 8.0.1
       imagemin-gifsicle:
         specifier: ^7.0.0
         version: 7.0.0
@@ -1629,26 +1640,22 @@ packages:
       '@types/babel__generator': 7.6.4
       '@types/babel__template': 7.4.1
       '@types/babel__traverse': 7.20.1
-    dev: true
 
   /@types/babel__generator@7.6.4:
     resolution: {integrity: sha512-tFkciB9j2K755yrTALxD44McOrk+gfpIpvC3sxHjRawj6PfnQxrse4Clq5y/Rq+G3mrBurMax/lG8Qn2t9mSsg==}
     dependencies:
       '@babel/types': 7.22.19
-    dev: true
 
   /@types/babel__template@7.4.1:
     resolution: {integrity: sha512-azBFKemX6kMg5Io+/rdGT0dkGreboUVR0Cdm3fz9QJWpaQGJRQXl7C+6hOTCZcMll7KFyEQpgbYI2lHdsS4U7g==}
     dependencies:
       '@babel/parser': 7.22.16
       '@babel/types': 7.22.19
-    dev: true
 
   /@types/babel__traverse@7.20.1:
     resolution: {integrity: sha512-MitHFXnhtgwsGZWtT68URpOvLN4EREih1u3QtQiN4VdAxWKRVvGCSvw/Qth0M0Qq3pJpnGOu5JaM/ydK7OGbqg==}
     dependencies:
       '@babel/types': 7.22.19
-    dev: true
 
   /@types/browser-sync@2.27.1:
     resolution: {integrity: sha512-p/qAU+3dqq/CqobNiiZkIsernNfQe/35QEtor8Oae/WWgMLLhceFogCaAMe7pO4T8Z5WL/Co522YBo2sk/I7AQ==}
@@ -1742,7 +1749,6 @@ packages:
     resolution: {integrity: sha512-DSpM//dRPzme7doePGkmR1uoquHi0h0ElaA5qFnxHECfFcB8z/jhMI8eqmxWNpHn9ZG18p4PC918sZLhR0cr5A==}
     dependencies:
       '@types/node': 20.6.2
-    dev: true
 
   /@types/is-ci@3.0.0:
     resolution: {integrity: sha512-Q0Op0hdWbYd1iahB+IFNQcWXFq4O0Q5MwQP7uN0souuQ4rPg1vEYcnIOfr1gY+M+6rc8FGoRaBO1mOOvL29sEQ==}
@@ -1777,6 +1783,10 @@ packages:
     resolution: {integrity: sha512-RbSSoHliUbnXj3ny0CNFOoxrIDV6SUGyStHsvDqosw6CkdPV8TtWGlfecuK4ToyMEAql6pzNxgCFKanovUzlgQ==}
     dev: true
 
+  /@types/json5@0.0.29:
+    resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
+    dev: true
+
   /@types/jsonfile@6.1.1:
     resolution: {integrity: sha512-GSgiRCVeapDN+3pqA35IkQwasaCh/0YFH5dEF6S88iDvEn901DjOeH3/QPY+XYP1DFzDZPvIvfeEgk+7br5png==}
     dependencies:
@@ -1791,7 +1801,7 @@ packages:
 
   /@types/less@3.0.4:
     resolution: {integrity: sha512-djlMpTdDF+tLaqVpK/0DWGNIr7BFjN8ykDLkgS0sQGYYLop51imRRE3foTjl+dMAH1zFE8bMZAG0VbYPEcSgsA==}
-    dev: true
+    dev: false
 
   /@types/mdast@3.0.12:
     resolution: {integrity: sha512-DT+iNIRNX884cx0/Q1ja7NyUPpZuv0KPyL5rGNxm1WC1OtHstl7n4Jb7nk+xacNShQMbczJjt8uFzznpp6kYBg==}
@@ -1866,7 +1876,7 @@ packages:
     resolution: {integrity: sha512-98a0QrJorrq8+Vsan9yfxol2Qr6nvUWBeV3oYnSMks4QdLMebAzZvRd9IuoZOcnB6Erfjcjn1J2J+63MPCxJnw==}
     dependencies:
       '@types/node': 20.6.2
-    dev: true
+    dev: false
 
   /@types/svgo@2.6.4:
     resolution: {integrity: sha512-l4cmyPEckf8moNYHdJ+4wkHvFxjyW6ulm9l4YGaOxeyBWPhBOT0gvni1InpFPdzx1dKf/2s62qGITwxNWnPQng==}
@@ -2039,9 +2049,9 @@ packages:
       prettier-plugin-tailwindcss:
         optional: true
     dependencies:
-      postcss: 8.4.29
+      postcss: 8.4.30
       prettier: 3.0.3
-      prettier-plugin-css-order: 2.0.0(postcss@8.4.29)(prettier@3.0.3)
+      prettier-plugin-css-order: 2.0.0(postcss@8.4.30)(prettier@3.0.3)
       prettier-plugin-jsdoc: 1.0.1(prettier@3.0.3)
       prettier-plugin-organize-imports: 3.2.3(prettier@3.0.3)(typescript@5.2.2)
       prettier-plugin-packagejson: 2.4.5(prettier@3.0.3)
@@ -2194,6 +2204,17 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: false
 
+  /array-includes@3.1.7:
+    resolution: {integrity: sha512-dlcsNBIiWhPkHdOEEKnehA+RNUWDc4UqFtnIXU4uuYDPtA4LDkr7qip2p0VvFAEXNDr0yWZ9PJyIRiGjRLQzwQ==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind: 1.0.2
+      define-properties: 1.2.0
+      es-abstract: 1.22.1
+      get-intrinsic: 1.2.1
+      is-string: 1.0.7
+    dev: true
+
   /array-union@2.1.0:
     resolution: {integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==}
     engines: {node: '>=8'}
@@ -2204,8 +2225,29 @@ packages:
     engines: {node: '>=12'}
     dev: false
 
+  /array.prototype.findlastindex@1.2.3:
+    resolution: {integrity: sha512-LzLoiOMAxvy+Gd3BAq3B7VeIgPdo+Q8hthvKtXybMvRV0jrXfJM/t8mw7nNlpEcVlVUnCnM2KSX4XU5HmpodOA==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind: 1.0.2
+      define-properties: 1.2.0
+      es-abstract: 1.22.1
+      es-shim-unscopables: 1.0.0
+      get-intrinsic: 1.2.1
+    dev: true
+
   /array.prototype.flat@1.3.2:
     resolution: {integrity: sha512-djYB+Zx2vLewY8RWlNCUdHjDXs2XOgm602S9E7P/UpHgfeHL00cRiIF+IN/G/aUJ7kGPb6yO/ErDI5V2s8iycA==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind: 1.0.2
+      define-properties: 1.2.0
+      es-abstract: 1.22.1
+      es-shim-unscopables: 1.0.0
+    dev: true
+
+  /array.prototype.flatmap@1.3.2:
+    resolution: {integrity: sha512-Ewyx0c9PmpcsByhSW4r+9zDU7sGjFc86qf/kKtuSCRdhfbk0SNLLkaT5qvcHnRGgc5NP/ly/y+qkXkqONX54CQ==}
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind: 1.0.2
@@ -3088,22 +3130,22 @@ packages:
     dev: false
     optional: true
 
-  /css-declaration-sorter@6.4.1(postcss@8.4.29):
+  /css-declaration-sorter@6.4.1(postcss@8.4.30):
     resolution: {integrity: sha512-rtdthzxKuyq6IzqX6jEcIzQF/YqccluefyCYheovBOLhFT/drQA9zj/UbRAa9J7C0o6EG6u3E6g+vKkay7/k3g==}
     engines: {node: ^10 || ^12 || >=14}
     peerDependencies:
       postcss: ^8.0.9
     dependencies:
-      postcss: 8.4.29
+      postcss: 8.4.30
     dev: false
 
-  /css-declaration-sorter@7.0.3(postcss@8.4.29):
+  /css-declaration-sorter@7.0.3(postcss@8.4.30):
     resolution: {integrity: sha512-/PHObPdiAXf0H3LOZCyXgBLt5fiS5XGCml/Ylpkmr7ADgq94GffvdGxJEmsSLDo0XGzItJY79dusRka0e4UVLw==}
     engines: {node: ^14 || ^16 || >=18}
     peerDependencies:
       postcss: ^8.0.9
     dependencies:
-      postcss: 8.4.29
+      postcss: 8.4.30
     dev: true
 
   /css-select@4.3.0:
@@ -3159,62 +3201,62 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
-  /cssnano-preset-default@6.0.1(postcss@8.4.29):
+  /cssnano-preset-default@6.0.1(postcss@8.4.30):
     resolution: {integrity: sha512-7VzyFZ5zEB1+l1nToKyrRkuaJIx0zi/1npjvZfbBwbtNTzhLtlvYraK/7/uqmX2Wb2aQtd983uuGw79jAjLSuQ==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      css-declaration-sorter: 6.4.1(postcss@8.4.29)
-      cssnano-utils: 4.0.0(postcss@8.4.29)
-      postcss: 8.4.29
-      postcss-calc: 9.0.1(postcss@8.4.29)
-      postcss-colormin: 6.0.0(postcss@8.4.29)
-      postcss-convert-values: 6.0.0(postcss@8.4.29)
-      postcss-discard-comments: 6.0.0(postcss@8.4.29)
-      postcss-discard-duplicates: 6.0.0(postcss@8.4.29)
-      postcss-discard-empty: 6.0.0(postcss@8.4.29)
-      postcss-discard-overridden: 6.0.0(postcss@8.4.29)
-      postcss-merge-longhand: 6.0.0(postcss@8.4.29)
-      postcss-merge-rules: 6.0.1(postcss@8.4.29)
-      postcss-minify-font-values: 6.0.0(postcss@8.4.29)
-      postcss-minify-gradients: 6.0.0(postcss@8.4.29)
-      postcss-minify-params: 6.0.0(postcss@8.4.29)
-      postcss-minify-selectors: 6.0.0(postcss@8.4.29)
-      postcss-normalize-charset: 6.0.0(postcss@8.4.29)
-      postcss-normalize-display-values: 6.0.0(postcss@8.4.29)
-      postcss-normalize-positions: 6.0.0(postcss@8.4.29)
-      postcss-normalize-repeat-style: 6.0.0(postcss@8.4.29)
-      postcss-normalize-string: 6.0.0(postcss@8.4.29)
-      postcss-normalize-timing-functions: 6.0.0(postcss@8.4.29)
-      postcss-normalize-unicode: 6.0.0(postcss@8.4.29)
-      postcss-normalize-url: 6.0.0(postcss@8.4.29)
-      postcss-normalize-whitespace: 6.0.0(postcss@8.4.29)
-      postcss-ordered-values: 6.0.0(postcss@8.4.29)
-      postcss-reduce-initial: 6.0.0(postcss@8.4.29)
-      postcss-reduce-transforms: 6.0.0(postcss@8.4.29)
-      postcss-svgo: 6.0.0(postcss@8.4.29)
-      postcss-unique-selectors: 6.0.0(postcss@8.4.29)
+      css-declaration-sorter: 6.4.1(postcss@8.4.30)
+      cssnano-utils: 4.0.0(postcss@8.4.30)
+      postcss: 8.4.30
+      postcss-calc: 9.0.1(postcss@8.4.30)
+      postcss-colormin: 6.0.0(postcss@8.4.30)
+      postcss-convert-values: 6.0.0(postcss@8.4.30)
+      postcss-discard-comments: 6.0.0(postcss@8.4.30)
+      postcss-discard-duplicates: 6.0.0(postcss@8.4.30)
+      postcss-discard-empty: 6.0.0(postcss@8.4.30)
+      postcss-discard-overridden: 6.0.0(postcss@8.4.30)
+      postcss-merge-longhand: 6.0.0(postcss@8.4.30)
+      postcss-merge-rules: 6.0.1(postcss@8.4.30)
+      postcss-minify-font-values: 6.0.0(postcss@8.4.30)
+      postcss-minify-gradients: 6.0.0(postcss@8.4.30)
+      postcss-minify-params: 6.0.0(postcss@8.4.30)
+      postcss-minify-selectors: 6.0.0(postcss@8.4.30)
+      postcss-normalize-charset: 6.0.0(postcss@8.4.30)
+      postcss-normalize-display-values: 6.0.0(postcss@8.4.30)
+      postcss-normalize-positions: 6.0.0(postcss@8.4.30)
+      postcss-normalize-repeat-style: 6.0.0(postcss@8.4.30)
+      postcss-normalize-string: 6.0.0(postcss@8.4.30)
+      postcss-normalize-timing-functions: 6.0.0(postcss@8.4.30)
+      postcss-normalize-unicode: 6.0.0(postcss@8.4.30)
+      postcss-normalize-url: 6.0.0(postcss@8.4.30)
+      postcss-normalize-whitespace: 6.0.0(postcss@8.4.30)
+      postcss-ordered-values: 6.0.0(postcss@8.4.30)
+      postcss-reduce-initial: 6.0.0(postcss@8.4.30)
+      postcss-reduce-transforms: 6.0.0(postcss@8.4.30)
+      postcss-svgo: 6.0.0(postcss@8.4.30)
+      postcss-unique-selectors: 6.0.0(postcss@8.4.30)
     dev: false
 
-  /cssnano-utils@4.0.0(postcss@8.4.29):
+  /cssnano-utils@4.0.0(postcss@8.4.30):
     resolution: {integrity: sha512-Z39TLP+1E0KUcd7LGyF4qMfu8ZufI0rDzhdyAMsa/8UyNUU8wpS0fhdBxbQbv32r64ea00h4878gommRVg2BHw==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      postcss: 8.4.29
+      postcss: 8.4.30
     dev: false
 
-  /cssnano@6.0.1(postcss@8.4.29):
+  /cssnano@6.0.1(postcss@8.4.30):
     resolution: {integrity: sha512-fVO1JdJ0LSdIGJq68eIxOqFpIJrZqXUsBt8fkrBcztCQqAjQD51OhZp7tc0ImcbwXD4k7ny84QTV90nZhmqbkg==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      cssnano-preset-default: 6.0.1(postcss@8.4.29)
+      cssnano-preset-default: 6.0.1(postcss@8.4.30)
       lilconfig: 2.1.0
-      postcss: 8.4.29
+      postcss: 8.4.30
     dev: false
 
   /csso@4.2.0:
@@ -3300,6 +3342,17 @@ packages:
     dependencies:
       ms: 2.0.0
     dev: false
+
+  /debug@3.2.7:
+    resolution: {integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+    dependencies:
+      ms: 2.1.3
+    dev: true
 
   /debug@4.3.2:
     resolution: {integrity: sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==}
@@ -3539,6 +3592,13 @@ packages:
 
   /dlv@1.1.3:
     resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
+    dev: true
+
+  /doctrine@2.1.0:
+    resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      esutils: 2.0.3
     dev: true
 
   /doctrine@3.0.0:
@@ -3922,6 +3982,80 @@ packages:
   /escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
+    dev: true
+
+  /eslint-import-resolver-node@0.3.9:
+    resolution: {integrity: sha512-WFj2isz22JahUv+B788TlO3N6zL3nNJGU8CcZbPZvVEkBPaJdCV4vy5wyghty5ROFbCRnm132v8BScu5/1BQ8g==}
+    dependencies:
+      debug: 3.2.7
+      is-core-module: 2.13.0
+      resolve: 1.22.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /eslint-module-utils@2.8.0(@typescript-eslint/parser@6.7.0)(eslint-import-resolver-node@0.3.9)(eslint@8.49.0):
+    resolution: {integrity: sha512-aWajIYfsqCKRDgUfjEXNN/JlrzauMuSEy5sbd7WXbtW3EH6A6MpwEh42c7qD+MqQo9QMJ6fWLAeIJynx0g6OAw==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint: '*'
+      eslint-import-resolver-node: '*'
+      eslint-import-resolver-typescript: '*'
+      eslint-import-resolver-webpack: '*'
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
+      eslint:
+        optional: true
+      eslint-import-resolver-node:
+        optional: true
+      eslint-import-resolver-typescript:
+        optional: true
+      eslint-import-resolver-webpack:
+        optional: true
+    dependencies:
+      '@typescript-eslint/parser': 6.7.0(eslint@8.49.0)(typescript@5.2.2)
+      debug: 3.2.7
+      eslint: 8.49.0
+      eslint-import-resolver-node: 0.3.9
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /eslint-plugin-import@2.28.1(@typescript-eslint/parser@6.7.0)(eslint@8.49.0):
+    resolution: {integrity: sha512-9I9hFlITvOV55alzoKBI+K9q74kv0iKMeY6av5+umsNwayt59fz692daGyjR+oStBQgx6nwR9rXldDev3Clw+A==}
+    engines: {node: '>=4'}
+    peerDependencies:
+      '@typescript-eslint/parser': '*'
+      eslint: ^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8
+    peerDependenciesMeta:
+      '@typescript-eslint/parser':
+        optional: true
+    dependencies:
+      '@typescript-eslint/parser': 6.7.0(eslint@8.49.0)(typescript@5.2.2)
+      array-includes: 3.1.7
+      array.prototype.findlastindex: 1.2.3
+      array.prototype.flat: 1.3.2
+      array.prototype.flatmap: 1.3.2
+      debug: 3.2.7
+      doctrine: 2.1.0
+      eslint: 8.49.0
+      eslint-import-resolver-node: 0.3.9
+      eslint-module-utils: 2.8.0(@typescript-eslint/parser@6.7.0)(eslint-import-resolver-node@0.3.9)(eslint@8.49.0)
+      has: 1.0.3
+      is-core-module: 2.13.0
+      is-glob: 4.0.3
+      minimatch: 3.1.2
+      object.fromentries: 2.0.7
+      object.groupby: 1.0.1
+      object.values: 1.1.7
+      semver: 6.3.1
+      tsconfig-paths: 3.14.2
+    transitivePeerDependencies:
+      - eslint-import-resolver-typescript
+      - eslint-import-resolver-webpack
+      - supports-color
     dev: true
 
   /eslint-scope@7.2.2:
@@ -6058,6 +6192,13 @@ packages:
     dev: false
     optional: true
 
+  /json5@1.0.2:
+    resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
+    hasBin: true
+    dependencies:
+      minimist: 1.2.8
+    dev: true
+
   /json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
@@ -6790,7 +6931,6 @@ packages:
 
   /ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
-    dev: false
 
   /mz@2.7.0:
     resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
@@ -6921,6 +7061,33 @@ packages:
       define-properties: 1.2.0
       has-symbols: 1.0.3
       object-keys: 1.1.1
+    dev: true
+
+  /object.fromentries@2.0.7:
+    resolution: {integrity: sha512-UPbPHML6sL8PI/mOqPwsH4G6iyXcCGzLin8KvEPenOZN5lpCNBZZQ+V62vdjB1mQHrmqGQt5/OJzemUA+KJmEA==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind: 1.0.2
+      define-properties: 1.2.0
+      es-abstract: 1.22.1
+    dev: true
+
+  /object.groupby@1.0.1:
+    resolution: {integrity: sha512-HqaQtqLnp/8Bn4GL16cj+CUYbnpe1bh0TtEaWvybszDG4tgxCJuRpV8VGuvNaI1fAnI4lUJzDG55MXcOH4JZcQ==}
+    dependencies:
+      call-bind: 1.0.2
+      define-properties: 1.2.0
+      es-abstract: 1.22.1
+      get-intrinsic: 1.2.1
+    dev: true
+
+  /object.values@1.1.7:
+    resolution: {integrity: sha512-aU6xnDFYT3x17e/f0IiiwlGPTy2jzMySGfUB4fq6z7CV8l85CWHDk5ErhyhpfDHhrOMwGFhSQkhMGHaIotA6Ng==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      call-bind: 1.0.2
+      define-properties: 1.2.0
+      es-abstract: 1.22.1
     dev: true
 
   /on-finished@2.3.0:
@@ -7289,18 +7456,18 @@ packages:
       is-number-like: 1.0.8
     dev: false
 
-  /postcss-calc@9.0.1(postcss@8.4.29):
+  /postcss-calc@9.0.1(postcss@8.4.30):
     resolution: {integrity: sha512-TipgjGyzP5QzEhsOZUaIkeO5mKeMFpebWzRogWG/ysonUlnHcq5aJe0jOjpfzUU8PeSaBQnrE8ehR0QA5vs8PQ==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
       postcss: ^8.2.2
     dependencies:
-      postcss: 8.4.29
+      postcss: 8.4.30
       postcss-selector-parser: 6.0.13
       postcss-value-parser: 4.2.0
     dev: false
 
-  /postcss-colormin@6.0.0(postcss@8.4.29):
+  /postcss-colormin@6.0.0(postcss@8.4.30):
     resolution: {integrity: sha512-EuO+bAUmutWoZYgHn2T1dG1pPqHU6L4TjzPlu4t1wZGXQ/fxV16xg2EJmYi0z+6r+MGV1yvpx1BHkUaRrPa2bw==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
@@ -7309,89 +7476,89 @@ packages:
       browserslist: 4.21.10
       caniuse-api: 3.0.0
       colord: 2.9.3
-      postcss: 8.4.29
+      postcss: 8.4.30
       postcss-value-parser: 4.2.0
     dev: false
 
-  /postcss-convert-values@6.0.0(postcss@8.4.29):
+  /postcss-convert-values@6.0.0(postcss@8.4.30):
     resolution: {integrity: sha512-U5D8QhVwqT++ecmy8rnTb+RL9n/B806UVaS3m60lqle4YDFcpbS3ae5bTQIh3wOGUSDHSEtMYLs/38dNG7EYFw==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
       browserslist: 4.21.10
-      postcss: 8.4.29
+      postcss: 8.4.30
       postcss-value-parser: 4.2.0
     dev: false
 
-  /postcss-discard-comments@6.0.0(postcss@8.4.29):
+  /postcss-discard-comments@6.0.0(postcss@8.4.30):
     resolution: {integrity: sha512-p2skSGqzPMZkEQvJsgnkBhCn8gI7NzRH2683EEjrIkoMiwRELx68yoUJ3q3DGSGuQ8Ug9Gsn+OuDr46yfO+eFw==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      postcss: 8.4.29
+      postcss: 8.4.30
     dev: false
 
-  /postcss-discard-duplicates@6.0.0(postcss@8.4.29):
+  /postcss-discard-duplicates@6.0.0(postcss@8.4.30):
     resolution: {integrity: sha512-bU1SXIizMLtDW4oSsi5C/xHKbhLlhek/0/yCnoMQany9k3nPBq+Ctsv/9oMmyqbR96HYHxZcHyK2HR5P/mqoGA==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      postcss: 8.4.29
+      postcss: 8.4.30
     dev: false
 
-  /postcss-discard-empty@6.0.0(postcss@8.4.29):
+  /postcss-discard-empty@6.0.0(postcss@8.4.30):
     resolution: {integrity: sha512-b+h1S1VT6dNhpcg+LpyiUrdnEZfICF0my7HAKgJixJLW7BnNmpRH34+uw/etf5AhOlIhIAuXApSzzDzMI9K/gQ==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      postcss: 8.4.29
+      postcss: 8.4.30
     dev: false
 
-  /postcss-discard-overridden@6.0.0(postcss@8.4.29):
+  /postcss-discard-overridden@6.0.0(postcss@8.4.30):
     resolution: {integrity: sha512-4VELwssYXDFigPYAZ8vL4yX4mUepF/oCBeeIT4OXsJPYOtvJumyz9WflmJWTfDwCUcpDR+z0zvCWBXgTx35SVw==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      postcss: 8.4.29
+      postcss: 8.4.30
     dev: false
 
-  /postcss-import@15.1.0(postcss@8.4.29):
+  /postcss-import@15.1.0(postcss@8.4.30):
     resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       postcss: ^8.0.0
     dependencies:
-      postcss: 8.4.29
+      postcss: 8.4.30
       postcss-value-parser: 4.2.0
       read-cache: 1.0.0
       resolve: 1.22.4
     dev: true
 
-  /postcss-js@4.0.1(postcss@8.4.29):
+  /postcss-js@4.0.1(postcss@8.4.30):
     resolution: {integrity: sha512-dDLF8pEO191hJMtlHFPRa8xsizHaM82MLfNkUHdUtVEV3tgTp5oj+8qbEqYM57SLfc74KSbw//4SeJma2LRVIw==}
     engines: {node: ^12 || ^14 || >= 16}
     peerDependencies:
       postcss: ^8.4.21
     dependencies:
       camelcase-css: 2.0.1
-      postcss: 8.4.29
+      postcss: 8.4.30
     dev: true
 
-  /postcss-less@6.0.0(postcss@8.4.29):
+  /postcss-less@6.0.0(postcss@8.4.30):
     resolution: {integrity: sha512-FPX16mQLyEjLzEuuJtxA8X3ejDLNGGEG503d2YGZR5Ask1SpDN8KmZUMpzCvyalWRywAn1n1VOA5dcqfCLo5rg==}
     engines: {node: '>=12'}
     peerDependencies:
       postcss: ^8.3.5
     dependencies:
-      postcss: 8.4.29
+      postcss: 8.4.30
     dev: true
 
-  /postcss-load-config@4.0.1(postcss@8.4.29):
+  /postcss-load-config@4.0.1(postcss@8.4.30):
     resolution: {integrity: sha512-vEJIc8RdiBRu3oRAI0ymerOn+7rPuMvRXslTvZUKZonDHFIczxztIyJ1urxM1x9JXEikvpWWTUUqal5j/8QgvA==}
     engines: {node: '>= 14'}
     peerDependencies:
@@ -7404,22 +7571,22 @@ packages:
         optional: true
     dependencies:
       lilconfig: 2.1.0
-      postcss: 8.4.29
+      postcss: 8.4.30
       yaml: 2.3.2
     dev: true
 
-  /postcss-merge-longhand@6.0.0(postcss@8.4.29):
+  /postcss-merge-longhand@6.0.0(postcss@8.4.30):
     resolution: {integrity: sha512-4VSfd1lvGkLTLYcxFuISDtWUfFS4zXe0FpF149AyziftPFQIWxjvFSKhA4MIxMe4XM3yTDgQMbSNgzIVxChbIg==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      postcss: 8.4.29
+      postcss: 8.4.30
       postcss-value-parser: 4.2.0
-      stylehacks: 6.0.0(postcss@8.4.29)
+      stylehacks: 6.0.0(postcss@8.4.30)
     dev: false
 
-  /postcss-merge-rules@6.0.1(postcss@8.4.29):
+  /postcss-merge-rules@6.0.1(postcss@8.4.30):
     resolution: {integrity: sha512-a4tlmJIQo9SCjcfiCcCMg/ZCEe0XTkl/xK0XHBs955GWg9xDX3NwP9pwZ78QUOWB8/0XCjZeJn98Dae0zg6AAw==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
@@ -7427,167 +7594,167 @@ packages:
     dependencies:
       browserslist: 4.21.10
       caniuse-api: 3.0.0
-      cssnano-utils: 4.0.0(postcss@8.4.29)
-      postcss: 8.4.29
+      cssnano-utils: 4.0.0(postcss@8.4.30)
+      postcss: 8.4.30
       postcss-selector-parser: 6.0.13
     dev: false
 
-  /postcss-minify-font-values@6.0.0(postcss@8.4.29):
+  /postcss-minify-font-values@6.0.0(postcss@8.4.30):
     resolution: {integrity: sha512-zNRAVtyh5E8ndZEYXA4WS8ZYsAp798HiIQ1V2UF/C/munLp2r1UGHwf1+6JFu7hdEhJFN+W1WJQKBrtjhFgEnA==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      postcss: 8.4.29
+      postcss: 8.4.30
       postcss-value-parser: 4.2.0
     dev: false
 
-  /postcss-minify-gradients@6.0.0(postcss@8.4.29):
+  /postcss-minify-gradients@6.0.0(postcss@8.4.30):
     resolution: {integrity: sha512-wO0F6YfVAR+K1xVxF53ueZJza3L+R3E6cp0VwuXJQejnNUH0DjcAFe3JEBeTY1dLwGa0NlDWueCA1VlEfiKgAA==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
       colord: 2.9.3
-      cssnano-utils: 4.0.0(postcss@8.4.29)
-      postcss: 8.4.29
+      cssnano-utils: 4.0.0(postcss@8.4.30)
+      postcss: 8.4.30
       postcss-value-parser: 4.2.0
     dev: false
 
-  /postcss-minify-params@6.0.0(postcss@8.4.29):
+  /postcss-minify-params@6.0.0(postcss@8.4.30):
     resolution: {integrity: sha512-Fz/wMQDveiS0n5JPcvsMeyNXOIMrwF88n7196puSuQSWSa+/Ofc1gDOSY2xi8+A4PqB5dlYCKk/WfqKqsI+ReQ==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
       browserslist: 4.21.10
-      cssnano-utils: 4.0.0(postcss@8.4.29)
-      postcss: 8.4.29
+      cssnano-utils: 4.0.0(postcss@8.4.30)
+      postcss: 8.4.30
       postcss-value-parser: 4.2.0
     dev: false
 
-  /postcss-minify-selectors@6.0.0(postcss@8.4.29):
+  /postcss-minify-selectors@6.0.0(postcss@8.4.30):
     resolution: {integrity: sha512-ec/q9JNCOC2CRDNnypipGfOhbYPuUkewGwLnbv6omue/PSASbHSU7s6uSQ0tcFRVv731oMIx8k0SP4ZX6be/0g==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      postcss: 8.4.29
+      postcss: 8.4.30
       postcss-selector-parser: 6.0.13
     dev: false
 
-  /postcss-nested@6.0.1(postcss@8.4.29):
+  /postcss-nested@6.0.1(postcss@8.4.30):
     resolution: {integrity: sha512-mEp4xPMi5bSWiMbsgoPfcP74lsWLHkQbZc3sY+jWYd65CUwXrUaTp0fmNpa01ZcETKlIgUdFN/MpS2xZtqL9dQ==}
     engines: {node: '>=12.0'}
     peerDependencies:
       postcss: ^8.2.14
     dependencies:
-      postcss: 8.4.29
+      postcss: 8.4.30
       postcss-selector-parser: 6.0.13
     dev: true
 
-  /postcss-normalize-charset@6.0.0(postcss@8.4.29):
+  /postcss-normalize-charset@6.0.0(postcss@8.4.30):
     resolution: {integrity: sha512-cqundwChbu8yO/gSWkuFDmKrCZ2vJzDAocheT2JTd0sFNA4HMGoKMfbk2B+J0OmO0t5GUkiAkSM5yF2rSLUjgQ==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      postcss: 8.4.29
+      postcss: 8.4.30
     dev: false
 
-  /postcss-normalize-display-values@6.0.0(postcss@8.4.29):
+  /postcss-normalize-display-values@6.0.0(postcss@8.4.30):
     resolution: {integrity: sha512-Qyt5kMrvy7dJRO3OjF7zkotGfuYALETZE+4lk66sziWSPzlBEt7FrUshV6VLECkI4EN8Z863O6Nci4NXQGNzYw==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      postcss: 8.4.29
+      postcss: 8.4.30
       postcss-value-parser: 4.2.0
     dev: false
 
-  /postcss-normalize-positions@6.0.0(postcss@8.4.29):
+  /postcss-normalize-positions@6.0.0(postcss@8.4.30):
     resolution: {integrity: sha512-mPCzhSV8+30FZyWhxi6UoVRYd3ZBJgTRly4hOkaSifo0H+pjDYcii/aVT4YE6QpOil15a5uiv6ftnY3rm0igPg==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      postcss: 8.4.29
+      postcss: 8.4.30
       postcss-value-parser: 4.2.0
     dev: false
 
-  /postcss-normalize-repeat-style@6.0.0(postcss@8.4.29):
+  /postcss-normalize-repeat-style@6.0.0(postcss@8.4.30):
     resolution: {integrity: sha512-50W5JWEBiOOAez2AKBh4kRFm2uhrT3O1Uwdxz7k24aKtbD83vqmcVG7zoIwo6xI2FZ/HDlbrCopXhLeTpQib1A==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      postcss: 8.4.29
+      postcss: 8.4.30
       postcss-value-parser: 4.2.0
     dev: false
 
-  /postcss-normalize-string@6.0.0(postcss@8.4.29):
+  /postcss-normalize-string@6.0.0(postcss@8.4.30):
     resolution: {integrity: sha512-KWkIB7TrPOiqb8ZZz6homet2KWKJwIlysF5ICPZrXAylGe2hzX/HSf4NTX2rRPJMAtlRsj/yfkrWGavFuB+c0w==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      postcss: 8.4.29
+      postcss: 8.4.30
       postcss-value-parser: 4.2.0
     dev: false
 
-  /postcss-normalize-timing-functions@6.0.0(postcss@8.4.29):
+  /postcss-normalize-timing-functions@6.0.0(postcss@8.4.30):
     resolution: {integrity: sha512-tpIXWciXBp5CiFs8sem90IWlw76FV4oi6QEWfQwyeREVwUy39VSeSqjAT7X0Qw650yAimYW5gkl2Gd871N5SQg==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      postcss: 8.4.29
+      postcss: 8.4.30
       postcss-value-parser: 4.2.0
     dev: false
 
-  /postcss-normalize-unicode@6.0.0(postcss@8.4.29):
+  /postcss-normalize-unicode@6.0.0(postcss@8.4.30):
     resolution: {integrity: sha512-ui5crYkb5ubEUDugDc786L/Me+DXp2dLg3fVJbqyAl0VPkAeALyAijF2zOsnZyaS1HyfPuMH0DwyY18VMFVNkg==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
       browserslist: 4.21.10
-      postcss: 8.4.29
+      postcss: 8.4.30
       postcss-value-parser: 4.2.0
     dev: false
 
-  /postcss-normalize-url@6.0.0(postcss@8.4.29):
+  /postcss-normalize-url@6.0.0(postcss@8.4.30):
     resolution: {integrity: sha512-98mvh2QzIPbb02YDIrYvAg4OUzGH7s1ZgHlD3fIdTHLgPLRpv1ZTKJDnSAKr4Rt21ZQFzwhGMXxpXlfrUBKFHw==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      postcss: 8.4.29
+      postcss: 8.4.30
       postcss-value-parser: 4.2.0
     dev: false
 
-  /postcss-normalize-whitespace@6.0.0(postcss@8.4.29):
+  /postcss-normalize-whitespace@6.0.0(postcss@8.4.30):
     resolution: {integrity: sha512-7cfE1AyLiK0+ZBG6FmLziJzqQCpTQY+8XjMhMAz8WSBSCsCNNUKujgIgjCAmDT3cJ+3zjTXFkoD15ZPsckArVw==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      postcss: 8.4.29
+      postcss: 8.4.30
       postcss-value-parser: 4.2.0
     dev: false
 
-  /postcss-ordered-values@6.0.0(postcss@8.4.29):
+  /postcss-ordered-values@6.0.0(postcss@8.4.30):
     resolution: {integrity: sha512-K36XzUDpvfG/nWkjs6d1hRBydeIxGpKS2+n+ywlKPzx1nMYDYpoGbcjhj5AwVYJK1qV2/SDoDEnHzlPD6s3nMg==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      cssnano-utils: 4.0.0(postcss@8.4.29)
-      postcss: 8.4.29
+      cssnano-utils: 4.0.0(postcss@8.4.30)
+      postcss: 8.4.30
       postcss-value-parser: 4.2.0
     dev: false
 
-  /postcss-reduce-initial@6.0.0(postcss@8.4.29):
+  /postcss-reduce-initial@6.0.0(postcss@8.4.30):
     resolution: {integrity: sha512-s2UOnidpVuXu6JiiI5U+fV2jamAw5YNA9Fdi/GRK0zLDLCfXmSGqQtzpUPtfN66RtCbb9fFHoyZdQaxOB3WxVA==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
@@ -7595,26 +7762,26 @@ packages:
     dependencies:
       browserslist: 4.21.10
       caniuse-api: 3.0.0
-      postcss: 8.4.29
+      postcss: 8.4.30
     dev: false
 
-  /postcss-reduce-transforms@6.0.0(postcss@8.4.29):
+  /postcss-reduce-transforms@6.0.0(postcss@8.4.30):
     resolution: {integrity: sha512-FQ9f6xM1homnuy1wLe9lP1wujzxnwt1EwiigtWwuyf8FsqqXUDUp2Ulxf9A5yjlUOTdCJO6lonYjg1mgqIIi2w==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      postcss: 8.4.29
+      postcss: 8.4.30
       postcss-value-parser: 4.2.0
     dev: false
 
-  /postcss-scss@4.0.7(postcss@8.4.29):
+  /postcss-scss@4.0.7(postcss@8.4.30):
     resolution: {integrity: sha512-xPv2GseoyXPa58Nro7M73ZntttusuCmZdeOojUFR5PZDz2BR62vfYx1w9TyOnp1+nYFowgOMipsCBhxzVkAEPw==}
     engines: {node: '>=12.0'}
     peerDependencies:
       postcss: ^8.4.19
     dependencies:
-      postcss: 8.4.29
+      postcss: 8.4.30
     dev: true
 
   /postcss-selector-parser@6.0.10:
@@ -7632,24 +7799,24 @@ packages:
       cssesc: 3.0.0
       util-deprecate: 1.0.2
 
-  /postcss-svgo@6.0.0(postcss@8.4.29):
+  /postcss-svgo@6.0.0(postcss@8.4.30):
     resolution: {integrity: sha512-r9zvj/wGAoAIodn84dR/kFqwhINp5YsJkLoujybWG59grR/IHx+uQ2Zo+IcOwM0jskfYX3R0mo+1Kip1VSNcvw==}
     engines: {node: ^14 || ^16 || >= 18}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      postcss: 8.4.29
+      postcss: 8.4.30
       postcss-value-parser: 4.2.0
       svgo: 3.0.2
     dev: false
 
-  /postcss-unique-selectors@6.0.0(postcss@8.4.29):
+  /postcss-unique-selectors@6.0.0(postcss@8.4.30):
     resolution: {integrity: sha512-EPQzpZNxOxP7777t73RQpZE5e9TrnCrkvp7AH7a0l89JmZiPnS82y216JowHXwpBCQitfyxrof9TK3rYbi7/Yw==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
-      postcss: 8.4.29
+      postcss: 8.4.30
       postcss-selector-parser: 6.0.13
     dev: false
 
@@ -7658,6 +7825,14 @@ packages:
 
   /postcss@8.4.29:
     resolution: {integrity: sha512-cbI+jaqIeu/VGqXEarWkRCCffhjgXc0qjBtXpqJhTBohMUjUQnbBr0xqX3vEKudc4iviTewcJo5ajcec5+wdJw==}
+    engines: {node: ^10 || ^12 || >=14}
+    dependencies:
+      nanoid: 3.3.6
+      picocolors: 1.0.0
+      source-map-js: 1.0.2
+
+  /postcss@8.4.30:
+    resolution: {integrity: sha512-7ZEao1g4kd68l97aWG/etQKPKq07us0ieSZ2TnFDk11i0ZfDW2AwKHYU8qv4MZKqN2fdBfg+7q0ES06UA73C1g==}
     engines: {node: ^10 || ^12 || >=14}
     dependencies:
       nanoid: 3.3.6
@@ -7689,15 +7864,15 @@ packages:
     engines: {node: '>=4'}
     dev: false
 
-  /prettier-plugin-css-order@2.0.0(postcss@8.4.29)(prettier@3.0.3):
+  /prettier-plugin-css-order@2.0.0(postcss@8.4.30)(prettier@3.0.3):
     resolution: {integrity: sha512-BCstZZ78G6FH/Ms1hl5ZLnSMso3ModM+SEZY8QrJzgyxjuCjSrS2bveeLq9wJMn20h9tAb6+C2FZPh5qdZ2qsw==}
     engines: {node: '>=16'}
     peerDependencies:
       prettier: 3.x
     dependencies:
-      css-declaration-sorter: 7.0.3(postcss@8.4.29)
-      postcss-less: 6.0.0(postcss@8.4.29)
-      postcss-scss: 4.0.7(postcss@8.4.29)
+      css-declaration-sorter: 7.0.3(postcss@8.4.30)
+      postcss-less: 6.0.0(postcss@8.4.30)
+      postcss-scss: 4.0.7(postcss@8.4.30)
       prettier: 3.0.3
     transitivePeerDependencies:
       - postcss
@@ -8902,14 +9077,14 @@ packages:
       peek-readable: 4.1.0
     dev: false
 
-  /stylehacks@6.0.0(postcss@8.4.29):
+  /stylehacks@6.0.0(postcss@8.4.30):
     resolution: {integrity: sha512-+UT589qhHPwz6mTlCLSt/vMNTJx8dopeJlZAlBMJPWA3ORqu6wmQY7FBXf+qD+FsqoBJODyqNxOUP3jdntFRdw==}
     engines: {node: ^14 || ^16 || >=18.0}
     peerDependencies:
       postcss: ^8.2.15
     dependencies:
       browserslist: 4.21.10
-      postcss: 8.4.29
+      postcss: 8.4.30
       postcss-selector-parser: 6.0.13
     dev: false
 
@@ -9125,11 +9300,11 @@ packages:
       normalize-path: 3.0.0
       object-hash: 3.0.0
       picocolors: 1.0.0
-      postcss: 8.4.29
-      postcss-import: 15.1.0(postcss@8.4.29)
-      postcss-js: 4.0.1(postcss@8.4.29)
-      postcss-load-config: 4.0.1(postcss@8.4.29)
-      postcss-nested: 6.0.1(postcss@8.4.29)
+      postcss: 8.4.30
+      postcss-import: 15.1.0(postcss@8.4.30)
+      postcss-js: 4.0.1(postcss@8.4.30)
+      postcss-load-config: 4.0.1(postcss@8.4.30)
+      postcss-nested: 6.0.1(postcss@8.4.30)
       postcss-selector-parser: 6.0.13
       resolve: 1.22.4
       sucrase: 3.34.0
@@ -9330,6 +9505,15 @@ packages:
 
   /ts-interface-checker@0.1.13:
     resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+    dev: true
+
+  /tsconfig-paths@3.14.2:
+    resolution: {integrity: sha512-o/9iXgCYc5L/JxCHPe3Hvh8Q/2xm5Z+p18PESBU6Ff33695QnCHBEjcytY2q19ua7Mbl/DavtBOLq+oG0RCL+g==}
+    dependencies:
+      '@types/json5': 0.0.29
+      json5: 1.0.2
+      minimist: 1.2.8
+      strip-bom: 3.0.0
     dev: true
 
   /tslib@2.6.2:
@@ -9718,7 +9902,7 @@ packages:
     dependencies:
       '@types/node': 20.6.2
       esbuild: 0.18.20
-      postcss: 8.4.29
+      postcss: 8.4.30
       rollup: 3.29.0
     optionalDependencies:
       fsevents: 2.3.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -294,9 +294,6 @@ importers:
       postcss:
         specifier: ^8.4.30
         version: 8.4.30
-      terser:
-        specifier: ^5.19.4
-        version: 5.19.4
 
   packages/preset-optimize:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -170,12 +170,13 @@ importers:
       fast-glob:
         specifier: ^3.3.1
         version: 3.3.1
-      less:
-        specifier: '>=2.7.3'
-        version: 2.7.3
       magefront:
         specifier: workspace:^
         version: link:../magefront
+    devDependencies:
+      less:
+        specifier: 2.7.3
+        version: 2.7.3
 
   packages/plugin-postcss:
     dependencies:
@@ -234,7 +235,7 @@ importers:
         specifier: workspace:^
         version: link:../magefront
       svelte:
-        specifier: ~4.2.0
+        specifier: ^4.2.0
         version: 4.2.0
 
   packages/plugin-terser:
@@ -2092,7 +2093,6 @@ packages:
     dependencies:
       co: 4.6.0
       json-stable-stringify: 1.0.2
-    dev: false
     optional: true
 
   /ajv@6.12.6:
@@ -2277,7 +2277,6 @@ packages:
   /asap@2.0.6:
     resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
     requiresBuild: true
-    dev: false
     optional: true
 
   /asn1@0.2.6:
@@ -2285,21 +2284,18 @@ packages:
     requiresBuild: true
     dependencies:
       safer-buffer: 2.1.2
-    dev: false
     optional: true
 
   /assert-plus@0.2.0:
     resolution: {integrity: sha512-u1L0ZLywRziOVjUhRxI0Qg9G+4RnFB9H/Rq40YWn0dieDgO7vAYeJz6jKAO6t/aruzlDFLAPkQTT87e+f8Imaw==}
     engines: {node: '>=0.8'}
     requiresBuild: true
-    dev: false
     optional: true
 
   /assert-plus@1.0.0:
     resolution: {integrity: sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==}
     engines: {node: '>=0.8'}
     requiresBuild: true
-    dev: false
     optional: true
 
   /async-each-series@0.1.1:
@@ -2320,7 +2316,6 @@ packages:
   /asynckit@0.4.0:
     resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
     requiresBuild: true
-    dev: false
     optional: true
 
   /autoprefixer@10.4.15(postcss@8.4.29):
@@ -2347,13 +2342,11 @@ packages:
   /aws-sign2@0.6.0:
     resolution: {integrity: sha512-JnJpAS0p9RmixkOvW2XwDxxzs1bd4/VAGIl6Q0EC5YOo+p+hqIhtDhn/nmFnB/xUNXbLkpE2mOjgVIBRKD4xYw==}
     requiresBuild: true
-    dev: false
     optional: true
 
   /aws4@1.12.0:
     resolution: {integrity: sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg==}
     requiresBuild: true
-    dev: false
     optional: true
 
   /axios@0.21.4(debug@4.3.2):
@@ -2466,7 +2459,6 @@ packages:
     requiresBuild: true
     dependencies:
       tweetnacl: 0.14.5
-    dev: false
     optional: true
 
   /better-path-resolve@1.0.0:
@@ -2555,7 +2547,6 @@ packages:
     requiresBuild: true
     dependencies:
       hoek: 2.16.3
-    dev: false
     optional: true
 
   /bplist-parser@0.2.0:
@@ -2797,7 +2788,6 @@ packages:
   /caseless@0.12.0:
     resolution: {integrity: sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==}
     requiresBuild: true
-    dev: false
     optional: true
 
   /caw@2.0.1:
@@ -2984,7 +2974,6 @@ packages:
     requiresBuild: true
     dependencies:
       delayed-stream: 1.0.0
-    dev: false
     optional: true
 
   /commander@2.20.3:
@@ -3064,7 +3053,6 @@ packages:
   /core-util-is@1.0.2:
     resolution: {integrity: sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==}
     requiresBuild: true
-    dev: false
 
   /cors@2.8.5:
     resolution: {integrity: sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==}
@@ -3127,7 +3115,6 @@ packages:
     requiresBuild: true
     dependencies:
       boom: 2.10.1
-    dev: false
     optional: true
 
   /css-declaration-sorter@6.4.1(postcss@8.4.30):
@@ -3329,7 +3316,6 @@ packages:
     requiresBuild: true
     dependencies:
       assert-plus: 1.0.0
-    dev: false
     optional: true
 
   /debug@2.6.9:
@@ -3519,7 +3505,6 @@ packages:
     resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
     engines: {node: '>=0.4.0'}
     requiresBuild: true
-    dev: false
     optional: true
 
   /depd@1.1.2:
@@ -3722,7 +3707,6 @@ packages:
     dependencies:
       jsbn: 0.1.1
       safer-buffer: 2.1.2
-    dev: false
     optional: true
 
   /ee-first@1.1.1:
@@ -3817,7 +3801,6 @@ packages:
     requiresBuild: true
     dependencies:
       prr: 1.0.1
-    dev: false
     optional: true
 
   /error-ex@1.3.2:
@@ -4338,7 +4321,6 @@ packages:
     resolution: {integrity: sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==}
     engines: {'0': node >=0.6.0}
     requiresBuild: true
-    dev: false
     optional: true
 
   /fast-deep-equal@3.1.3:
@@ -4556,7 +4538,6 @@ packages:
   /forever-agent@0.6.1:
     resolution: {integrity: sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==}
     requiresBuild: true
-    dev: false
     optional: true
 
   /form-data@2.1.4:
@@ -4567,7 +4548,6 @@ packages:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       mime-types: 2.1.35
-    dev: false
     optional: true
 
   /fraction.js@4.3.6:
@@ -4735,7 +4715,6 @@ packages:
     requiresBuild: true
     dependencies:
       assert-plus: 1.0.0
-    dev: false
     optional: true
 
   /gifsicle@5.3.0:
@@ -4921,7 +4900,6 @@ packages:
     resolution: {integrity: sha512-f8xf2GOR6Rgwc9FPTLNzgwB+JQ2/zMauYXSWmX5YV5acex6VomT0ocSuwR7BfXo5MpHi+jL+saaux2fwsGJDKQ==}
     engines: {node: '>=4'}
     requiresBuild: true
-    dev: false
     optional: true
 
   /har-validator@4.2.1:
@@ -4932,7 +4910,6 @@ packages:
     dependencies:
       ajv: 4.11.8
       har-schema: 1.0.5
-    dev: false
     optional: true
 
   /hard-rejection@2.1.0:
@@ -5029,7 +5006,6 @@ packages:
       cryptiles: 2.0.5
       hoek: 2.16.3
       sntp: 1.0.9
-    dev: false
     optional: true
 
   /hoek@2.16.3:
@@ -5037,7 +5013,6 @@ packages:
     engines: {node: '>=0.10.40'}
     deprecated: This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).
     requiresBuild: true
-    dev: false
     optional: true
 
   /hosted-git-info@2.8.9:
@@ -5091,7 +5066,6 @@ packages:
       assert-plus: 0.2.0
       jsprim: 1.4.2
       sshpk: 1.17.0
-    dev: false
     optional: true
 
   /human-id@1.0.2:
@@ -5131,7 +5105,6 @@ packages:
     engines: {node: '>=0.10.0'}
     hasBin: true
     requiresBuild: true
-    dev: false
     optional: true
 
   /imagemin-gifsicle@7.0.0:
@@ -5535,7 +5508,6 @@ packages:
   /is-typedarray@1.0.0:
     resolution: {integrity: sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==}
     requiresBuild: true
-    dev: false
     optional: true
 
   /is-utf8@0.2.1:
@@ -5579,7 +5551,6 @@ packages:
   /isstream@0.1.2:
     resolution: {integrity: sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==}
     requiresBuild: true
-    dev: false
     optional: true
 
   /istanbul-lib-coverage@3.2.0:
@@ -6144,7 +6115,6 @@ packages:
   /jsbn@0.1.1:
     resolution: {integrity: sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==}
     requiresBuild: true
-    dev: false
     optional: true
 
   /jsesc@2.5.2:
@@ -6171,7 +6141,6 @@ packages:
   /json-schema@0.4.0:
     resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
     requiresBuild: true
-    dev: false
     optional: true
 
   /json-stable-stringify-without-jsonify@1.0.1:
@@ -6183,13 +6152,11 @@ packages:
     requiresBuild: true
     dependencies:
       jsonify: 0.0.1
-    dev: false
     optional: true
 
   /json-stringify-safe@5.0.1:
     resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
     requiresBuild: true
-    dev: false
     optional: true
 
   /json5@1.0.2:
@@ -6231,7 +6198,6 @@ packages:
   /jsonify@0.0.1:
     resolution: {integrity: sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==}
     requiresBuild: true
-    dev: false
     optional: true
 
   /jsprim@1.4.2:
@@ -6243,7 +6209,6 @@ packages:
       extsprintf: 1.3.0
       json-schema: 0.4.0
       verror: 1.10.0
-    dev: false
     optional: true
 
   /junk@3.1.0:
@@ -6294,7 +6259,6 @@ packages:
       promise: 7.3.1
       request: 2.81.0
       source-map: 0.5.7
-    dev: false
 
   /leven@3.1.0:
     resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
@@ -6830,14 +6794,12 @@ packages:
   /mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
-    dev: false
 
   /mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
     dependencies:
       mime-db: 1.52.0
-    dev: false
 
   /mime@1.4.1:
     resolution: {integrity: sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==}
@@ -6850,7 +6812,6 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
     requiresBuild: true
-    dev: false
     optional: true
 
   /mime@3.0.0:
@@ -7032,7 +6993,6 @@ packages:
   /oauth-sign@0.8.2:
     resolution: {integrity: sha512-VlF07iu3VV3+BTXj43Nmp6Irt/G7j/NgEctUS6IweH1RGhURjjCc2NWtzXFPXXWWfc7hgbXQdtiQu2LGp6MxUg==}
     requiresBuild: true
-    dev: false
     optional: true
 
   /object-assign@4.1.1:
@@ -7383,7 +7343,6 @@ packages:
   /performance-now@0.2.0:
     resolution: {integrity: sha512-YHk5ez1hmMR5LOkb9iJkLKqoBlL7WD5M8ljC75ZfzXriuBIVNuecaXuU7e+hOwyqf24Wxhh7Vxgt7Hnw9288Tg==}
     requiresBuild: true
-    dev: false
     optional: true
 
   /periscopic@3.1.0:
@@ -8043,7 +8002,6 @@ packages:
     requiresBuild: true
     dependencies:
       asap: 2.0.6
-    dev: false
     optional: true
 
   /prompts@2.4.2:
@@ -8061,7 +8019,6 @@ packages:
   /prr@1.0.1:
     resolution: {integrity: sha512-yPw4Sng1gWghHQWj0B3ZggWUm4qVbPwPFcRG8KyxiU7J2OHFSoEHKS+EZ3fv5l1t9CyCiop6l/ZYeWbrgoQejw==}
     requiresBuild: true
-    dev: false
     optional: true
 
   /pseudomap@1.0.2:
@@ -8078,7 +8035,6 @@ packages:
   /punycode@1.4.1:
     resolution: {integrity: sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==}
     requiresBuild: true
-    dev: false
     optional: true
 
   /punycode@2.3.0:
@@ -8094,7 +8050,6 @@ packages:
     resolution: {integrity: sha512-LQy1Q1fcva/UsnP/6Iaa4lVeM49WiOitu2T4hZCyA/elLKu37L99qcBJk4VCCk+rdLvnMzfKyiN3SZTqdAZGSQ==}
     engines: {node: '>=0.6'}
     requiresBuild: true
-    dev: false
     optional: true
 
   /query-string@5.1.1:
@@ -8318,7 +8273,6 @@ packages:
       tough-cookie: 2.3.4
       tunnel-agent: 0.6.0
       uuid: 3.4.0
-    dev: false
     optional: true
 
   /require-directory@2.1.1:
@@ -8442,7 +8396,6 @@ packages:
 
   /safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
-    dev: false
 
   /safe-regex-test@1.0.0:
     resolution: {integrity: sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==}
@@ -8675,7 +8628,6 @@ packages:
     requiresBuild: true
     dependencies:
       hoek: 2.16.3
-    dev: false
     optional: true
 
   /socket.io-adapter@2.5.2:
@@ -8805,7 +8757,6 @@ packages:
     resolution: {integrity: sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==}
     engines: {node: '>=0.10.0'}
     requiresBuild: true
-    dev: false
     optional: true
 
   /source-map@0.6.1:
@@ -8870,7 +8821,6 @@ packages:
       jsbn: 0.1.1
       safer-buffer: 2.1.2
       tweetnacl: 0.14.5
-    dev: false
     optional: true
 
   /stable@0.1.8:
@@ -8985,7 +8935,6 @@ packages:
   /stringstream@0.0.6:
     resolution: {integrity: sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA==}
     requiresBuild: true
-    dev: false
     optional: true
 
   /strip-ansi@3.0.1:
@@ -9461,7 +9410,6 @@ packages:
     requiresBuild: true
     dependencies:
       punycode: 1.4.1
-    dev: false
     optional: true
 
   /trim-newlines@1.0.0:
@@ -9539,12 +9487,10 @@ packages:
     requiresBuild: true
     dependencies:
       safe-buffer: 5.2.1
-    dev: false
 
   /tweetnacl@0.14.5:
     resolution: {integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==}
     requiresBuild: true
-    dev: false
     optional: true
 
   /type-check@0.4.0:
@@ -9805,7 +9751,6 @@ packages:
     deprecated: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
     hasBin: true
     requiresBuild: true
-    dev: false
 
   /uvu@0.5.6:
     resolution: {integrity: sha512-+g8ENReyr8YsOc6fv/NVJs2vFdHBnBNdfE49rshrTzDWOlUx4Gq7KOS2GD8eqhy2j+Ejq29+SbKH8yjkAqXqoA==}
@@ -9846,7 +9791,6 @@ packages:
       assert-plus: 1.0.0
       core-util-is: 1.0.2
       extsprintf: 1.3.0
-    dev: false
     optional: true
 
   /vfile-message@2.0.4:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -175,8 +175,8 @@ importers:
         version: link:../magefront
     devDependencies:
       less:
-        specifier: 2.7.3
-        version: 2.7.3
+        specifier: 3.13.1
+        version: 3.13.1
 
   packages/plugin-postcss:
     dependencies:
@@ -271,8 +271,8 @@ importers:
         specifier: ^6.0.1
         version: 6.0.1(postcss@8.4.30)
       less:
-        specifier: 2.7.3
-        version: 2.7.3
+        specifier: 3.13.1
+        version: 3.13.1
       magefront:
         specifier: workspace:^
         version: link:../magefront
@@ -2084,14 +2084,6 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  /ajv@4.11.8:
-    resolution: {integrity: sha512-I/bSHSNEcFFqXLf91nchoNB9D1Kie3QKcWdchYUaoIg1+1bdWDkdfdlvdIOJbi9U8xR0y+MWc5D+won9v95WlQ==}
-    requiresBuild: true
-    dependencies:
-      co: 4.6.0
-      json-stable-stringify: 1.0.2
-    optional: true
-
   /ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
     dependencies:
@@ -2271,30 +2263,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dev: true
 
-  /asap@2.0.6:
-    resolution: {integrity: sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==}
-    requiresBuild: true
-    optional: true
-
-  /asn1@0.2.6:
-    resolution: {integrity: sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==}
-    requiresBuild: true
-    dependencies:
-      safer-buffer: 2.1.2
-    optional: true
-
-  /assert-plus@0.2.0:
-    resolution: {integrity: sha512-u1L0ZLywRziOVjUhRxI0Qg9G+4RnFB9H/Rq40YWn0dieDgO7vAYeJz6jKAO6t/aruzlDFLAPkQTT87e+f8Imaw==}
-    engines: {node: '>=0.8'}
-    requiresBuild: true
-    optional: true
-
-  /assert-plus@1.0.0:
-    resolution: {integrity: sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==}
-    engines: {node: '>=0.8'}
-    requiresBuild: true
-    optional: true
-
   /async-each-series@0.1.1:
     resolution: {integrity: sha512-p4jj6Fws4Iy2m0iCmI2am2ZNZCgbdgE+P8F/8csmn2vx7ixXrO2zGcuNsD46X5uZSVecmkEy/M06X2vG8KD6dQ==}
     engines: {node: '>=0.8.0'}
@@ -2309,11 +2277,6 @@ packages:
   /async@3.2.4:
     resolution: {integrity: sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==}
     dev: false
-
-  /asynckit@0.4.0:
-    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
-    requiresBuild: true
-    optional: true
 
   /autoprefixer@10.4.15(postcss@8.4.29):
     resolution: {integrity: sha512-KCuPB8ZCIqFdA4HwKXsvz7j6gvSDNhDP7WnUjBleRkKjPdvCmHFuQ77ocavI8FT6NdvlBnE2UFr2H4Mycn8Vew==}
@@ -2335,16 +2298,6 @@ packages:
     resolution: {integrity: sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==}
     engines: {node: '>= 0.4'}
     dev: true
-
-  /aws-sign2@0.6.0:
-    resolution: {integrity: sha512-JnJpAS0p9RmixkOvW2XwDxxzs1bd4/VAGIl6Q0EC5YOo+p+hqIhtDhn/nmFnB/xUNXbLkpE2mOjgVIBRKD4xYw==}
-    requiresBuild: true
-    optional: true
-
-  /aws4@1.12.0:
-    resolution: {integrity: sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg==}
-    requiresBuild: true
-    optional: true
 
   /axios@0.21.4(debug@4.3.2):
     resolution: {integrity: sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==}
@@ -2451,13 +2404,6 @@ packages:
     resolution: {integrity: sha512-x+VAiMRL6UPkx+kudNvxTl6hB2XNNCG2r+7wixVfIYwu/2HKRXimwQyaumLjMveWvT2Hkd/cAJw+QBMfJ/EKVw==}
     dev: false
 
-  /bcrypt-pbkdf@1.0.2:
-    resolution: {integrity: sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==}
-    requiresBuild: true
-    dependencies:
-      tweetnacl: 0.14.5
-    optional: true
-
   /better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
     engines: {node: '>=4'}
@@ -2536,15 +2482,6 @@ packages:
   /boolbase@1.0.0:
     resolution: {integrity: sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==}
     dev: false
-
-  /boom@2.10.1:
-    resolution: {integrity: sha512-KbiZEa9/vofNcVJXGwdWWn25reQ3V3dHBWbS07FTF3/TOehLnm9GEhJV4T6ZvGPkShRpmUqYwnaCrkj0mRnP6Q==}
-    engines: {node: '>=0.10.40'}
-    deprecated: This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).
-    requiresBuild: true
-    dependencies:
-      hoek: 2.16.3
-    optional: true
 
   /bplist-parser@0.2.0:
     resolution: {integrity: sha512-z0M+byMThzQmD9NILRniCUXYsYpjwnlO8N5uCFaCqIOpqRsJCrQL9NK3JsD67CN5a08nF5oIL2bD6loTdHOuKw==}
@@ -2782,11 +2719,6 @@ packages:
     engines: {node: '>= 0.8.0'}
     dev: true
 
-  /caseless@0.12.0:
-    resolution: {integrity: sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==}
-    requiresBuild: true
-    optional: true
-
   /caw@2.0.1:
     resolution: {integrity: sha512-Cg8/ZSBEa8ZVY9HspcGUYaK63d/bN7rqS3CYCzEGUxuYv6UlmcjzDUz2fCFFHyTvUW5Pk0I+3hkA3iXlIj6guA==}
     engines: {node: '>=4'}
@@ -2904,6 +2836,7 @@ packages:
   /co@4.6.0:
     resolution: {integrity: sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==}
     engines: {iojs: '>= 1.0.0', node: '>= 0.12.0'}
+    dev: true
 
   /code-red@1.0.4:
     resolution: {integrity: sha512-7qJWqItLA8/VPVlKJlFXU+NBlo/qyfs39aJcuMT/2ere32ZqvF5OSxgdM5xOfJJ7O429gg2HM47y8v9P+9wrNw==}
@@ -2964,14 +2897,6 @@ packages:
       color: 3.2.1
       text-hex: 1.0.0
     dev: false
-
-  /combined-stream@1.0.8:
-    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
-    engines: {node: '>= 0.8'}
-    requiresBuild: true
-    dependencies:
-      delayed-stream: 1.0.0
-    optional: true
 
   /commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
@@ -3047,9 +2972,15 @@ packages:
     engines: {node: '>= 0.6'}
     dev: true
 
+  /copy-anything@2.0.6:
+    resolution: {integrity: sha512-1j20GZTsvKNkc4BY3NpMOM8tt///wY3FpIzozTOFO2ffuZcV61nojHXVKIy3WM+7ADCy5FVhdZYHYDdgTU0yJw==}
+    dependencies:
+      is-what: 3.14.1
+
   /core-util-is@1.0.2:
     resolution: {integrity: sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==}
     requiresBuild: true
+    dev: false
 
   /cors@2.8.5:
     resolution: {integrity: sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==}
@@ -3104,15 +3035,6 @@ packages:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
-
-  /cryptiles@2.0.5:
-    resolution: {integrity: sha512-FFN5KwpvvQTTS5hWPxrU8/QE4kQUc6uwZcrnlMBN82t1MgAtq8mnoDwINBly9Tdr02seeIIhtdF+UH1feBYGog==}
-    engines: {node: '>=0.10.40'}
-    deprecated: This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).
-    requiresBuild: true
-    dependencies:
-      boom: 2.10.1
-    optional: true
 
   /css-declaration-sorter@6.4.1(postcss@8.4.30):
     resolution: {integrity: sha512-rtdthzxKuyq6IzqX6jEcIzQF/YqccluefyCYheovBOLhFT/drQA9zj/UbRAa9J7C0o6EG6u3E6g+vKkay7/k3g==}
@@ -3307,14 +3229,6 @@ packages:
       type: 1.2.0
     dev: false
 
-  /dashdash@1.14.1:
-    resolution: {integrity: sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==}
-    engines: {node: '>=0.10'}
-    requiresBuild: true
-    dependencies:
-      assert-plus: 1.0.0
-    optional: true
-
   /debug@2.6.9:
     resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
     peerDependencies:
@@ -3497,12 +3411,6 @@ packages:
       has-property-descriptors: 1.0.0
       object-keys: 1.1.1
     dev: true
-
-  /delayed-stream@1.0.0:
-    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
-    engines: {node: '>=0.4.0'}
-    requiresBuild: true
-    optional: true
 
   /depd@1.1.2:
     resolution: {integrity: sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==}
@@ -3697,14 +3605,6 @@ packages:
     dependencies:
       chalk: 4.1.2
     dev: false
-
-  /ecc-jsbn@0.1.2:
-    resolution: {integrity: sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==}
-    requiresBuild: true
-    dependencies:
-      jsbn: 0.1.1
-      safer-buffer: 2.1.2
-    optional: true
 
   /ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
@@ -4300,6 +4200,7 @@ packages:
   /extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
     requiresBuild: true
+    dev: true
 
   /extendable-error@0.1.7:
     resolution: {integrity: sha512-UOiS2in6/Q0FK0R0q6UY9vYpQ21mr/Qn1KOnte7vsACuNJf514WvCCUHSRCPcgjPT2bAhNIJdlE6bVap1GKmeg==}
@@ -4313,12 +4214,6 @@ packages:
       iconv-lite: 0.4.24
       tmp: 0.0.33
     dev: true
-
-  /extsprintf@1.3.0:
-    resolution: {integrity: sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==}
-    engines: {'0': node >=0.6.0}
-    requiresBuild: true
-    optional: true
 
   /fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
@@ -4532,21 +4427,6 @@ packages:
       is-callable: 1.2.7
     dev: true
 
-  /forever-agent@0.6.1:
-    resolution: {integrity: sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==}
-    requiresBuild: true
-    optional: true
-
-  /form-data@2.1.4:
-    resolution: {integrity: sha512-8HWGSLAPr+AG0hBpsqi5Ob8HrLStN/LWeqhpFl14d7FJgHK48TmgLoALPz69XSUR65YJzDfLUX/BM8+MLJLghQ==}
-    engines: {node: '>= 0.12'}
-    requiresBuild: true
-    dependencies:
-      asynckit: 0.4.0
-      combined-stream: 1.0.8
-      mime-types: 2.1.35
-    optional: true
-
   /fraction.js@4.3.6:
     resolution: {integrity: sha512-n2aZ9tNfYDwaHhvFTkhFErqOMIb8uyzSQ+vGJBjZyanAKZVbGUQ1sngfk9FdkBw7G26O7AgNjLcecLffD1c7eg==}
     dev: true
@@ -4706,13 +4586,6 @@ packages:
       call-bind: 1.0.2
       get-intrinsic: 1.2.1
     dev: true
-
-  /getpass@0.1.7:
-    resolution: {integrity: sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==}
-    requiresBuild: true
-    dependencies:
-      assert-plus: 1.0.0
-    optional: true
 
   /gifsicle@5.3.0:
     resolution: {integrity: sha512-FJTpgdj1Ow/FITB7SVza5HlzXa+/lqEY0tHQazAJbuAdvyJtkH4wIdsR2K414oaTwRXHFLLF+tYbipj+OpYg+Q==}
@@ -4893,22 +4766,6 @@ packages:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
     dev: true
 
-  /har-schema@1.0.5:
-    resolution: {integrity: sha512-f8xf2GOR6Rgwc9FPTLNzgwB+JQ2/zMauYXSWmX5YV5acex6VomT0ocSuwR7BfXo5MpHi+jL+saaux2fwsGJDKQ==}
-    engines: {node: '>=4'}
-    requiresBuild: true
-    optional: true
-
-  /har-validator@4.2.1:
-    resolution: {integrity: sha512-5Gbp6RAftMYYV3UEI4c4Vv3+a4dQ7taVyvHt+/L6kRt+f4HX1GweAk5UDWN0SvdVnRBzGQ6OG89pGaD9uSFnVw==}
-    engines: {node: '>=4'}
-    deprecated: this library is no longer supported
-    requiresBuild: true
-    dependencies:
-      ajv: 4.11.8
-      har-schema: 1.0.5
-    optional: true
-
   /hard-rejection@2.1.0:
     resolution: {integrity: sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==}
     engines: {node: '>=6'}
@@ -4993,25 +4850,6 @@ packages:
       '@types/hast': 3.0.1
     dev: true
 
-  /hawk@3.1.3:
-    resolution: {integrity: sha512-X8xbmTc1cbPXcQV4WkLcRMALuyoxhfpFATmyuCxJPOAvrDS4DNnsTAOmKUxMTOWU6TzrTOkxPKwIx5ZOpJVSrg==}
-    engines: {node: '>=0.10.32'}
-    deprecated: This module moved to @hapi/hawk. Please make sure to switch over as this distribution is no longer supported and may contain bugs and critical security issues.
-    requiresBuild: true
-    dependencies:
-      boom: 2.10.1
-      cryptiles: 2.0.5
-      hoek: 2.16.3
-      sntp: 1.0.9
-    optional: true
-
-  /hoek@2.16.3:
-    resolution: {integrity: sha512-V6Yw1rIcYV/4JsnggjBU0l4Kr+EXhpwqXRusENU1Xx6ro00IHPHYNynCuBTOZAPlr3AAmLvchH9I7N/VUdvOwQ==}
-    engines: {node: '>=0.10.40'}
-    deprecated: This version has been deprecated in accordance with the hapi support policy (hapi.im/support). Please upgrade to the latest version to get the best features, bug fixes, and security patches. If you are unable to upgrade at this time, paid support is available for older versions (hapi.im/commercial).
-    requiresBuild: true
-    optional: true
-
   /hosted-git-info@2.8.9:
     resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}
 
@@ -5054,16 +4892,6 @@ packages:
     transitivePeerDependencies:
       - debug
     dev: false
-
-  /http-signature@1.1.1:
-    resolution: {integrity: sha512-iUn0NcRULlDGtqNLN1Jxmzayk8ogm7NToldASyZBpM2qggbphjXzNOiw3piN8tgz+e/DRs6X5gAzFwTI6BCRcg==}
-    engines: {node: '>=0.8', npm: '>=1.3.7'}
-    requiresBuild: true
-    dependencies:
-      assert-plus: 0.2.0
-      jsprim: 1.4.2
-      sshpk: 1.17.0
-    optional: true
 
   /human-id@1.0.2:
     resolution: {integrity: sha512-UNopramDEhHJD+VR+ehk8rOslwSfByxPIZyJRfV739NDhN5LF1fa1MqnzKm2lGTQRjNrjK19Q5fhkgIfjlVUKw==}
@@ -5502,11 +5330,6 @@ packages:
       which-typed-array: 1.1.11
     dev: true
 
-  /is-typedarray@1.0.0:
-    resolution: {integrity: sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==}
-    requiresBuild: true
-    optional: true
-
   /is-utf8@0.2.1:
     resolution: {integrity: sha512-rMYPYvCzsXywIsldgLaSoPlw5PfoB/ssr7hY4pLfcodrA5M/eArza1a9VmTiNIBNMjOGr1Ow9mTyU2o69U6U9Q==}
     dev: false
@@ -5516,6 +5339,9 @@ packages:
     dependencies:
       call-bind: 1.0.2
     dev: true
+
+  /is-what@3.14.1:
+    resolution: {integrity: sha512-sNxgpk9793nzSs7bA6JQJGeIuRBQhAaNGG77kzYQgMkrID+lS6SlK07K5LaptscDlSaIgH+GPFzf+d75FVxozA==}
 
   /is-windows@1.0.2:
     resolution: {integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==}
@@ -5544,11 +5370,6 @@ packages:
 
   /isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
-
-  /isstream@0.1.2:
-    resolution: {integrity: sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==}
-    requiresBuild: true
-    optional: true
 
   /istanbul-lib-coverage@3.2.0:
     resolution: {integrity: sha512-eOeJ5BHCmHYvQK7xt9GkdHuzuCGS1Y6g9Gvnx3Ym33fz/HpLRYxiS0wHNr+m/MBC8B647Xt608vCDEvhl9c6Mw==}
@@ -6109,11 +5930,6 @@ packages:
       argparse: 2.0.1
     dev: true
 
-  /jsbn@0.1.1:
-    resolution: {integrity: sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==}
-    requiresBuild: true
-    optional: true
-
   /jsesc@2.5.2:
     resolution: {integrity: sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==}
     engines: {node: '>=4'}
@@ -6135,26 +5951,9 @@ packages:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
     dev: true
 
-  /json-schema@0.4.0:
-    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
-    requiresBuild: true
-    optional: true
-
   /json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
     dev: true
-
-  /json-stable-stringify@1.0.2:
-    resolution: {integrity: sha512-eunSSaEnxV12z+Z73y/j5N37/In40GK4GmsSy+tEHJMxknvqnA7/djeYtAgW0GsWHUfg+847WJjKaEylk2y09g==}
-    requiresBuild: true
-    dependencies:
-      jsonify: 0.0.1
-    optional: true
-
-  /json-stringify-safe@5.0.1:
-    resolution: {integrity: sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==}
-    requiresBuild: true
-    optional: true
 
   /json5@1.0.2:
     resolution: {integrity: sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==}
@@ -6192,22 +5991,6 @@ packages:
       graceful-fs: 4.2.11
     dev: false
 
-  /jsonify@0.0.1:
-    resolution: {integrity: sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==}
-    requiresBuild: true
-    optional: true
-
-  /jsprim@1.4.2:
-    resolution: {integrity: sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==}
-    engines: {node: '>=0.6.0'}
-    requiresBuild: true
-    dependencies:
-      assert-plus: 1.0.0
-      extsprintf: 1.3.0
-      json-schema: 0.4.0
-      verror: 1.10.0
-    optional: true
-
   /junk@3.1.0:
     resolution: {integrity: sha512-pBxcB3LFc8QVgdggvZWyeys+hnrNWg4OcZIU/1X59k5jQdLBlCsYGRQaz234SqoRLTCgMH00fY0xRJH+F9METQ==}
     engines: {node: '>=8'}
@@ -6243,19 +6026,21 @@ packages:
     resolution: {integrity: sha512-Xq9nH7KlWZmXAtodXDDRE7vs6DU1gTU8zYDHDiWLSip45Egwq3plLHzPn27NgvzL2r1LMPC1vdqh98sQxtqj4A==}
     dev: false
 
-  /less@2.7.3:
-    resolution: {integrity: sha512-KPdIJKWcEAb02TuJtaLrhue0krtRLoRoo7x6BNJIBelO00t/CCdJQUnHW5V34OnHMWzIktSalJxRO+FvytQlCQ==}
-    engines: {node: '>=0.12'}
+  /less@3.13.1:
+    resolution: {integrity: sha512-SwA1aQXGUvp+P5XdZslUOhhLnClSLIjWvJhmd+Vgib5BFIr9lMNlQwmwUNOjXThF/A0x+MCYYPeWEfeWiLRnTw==}
+    engines: {node: '>=6'}
     hasBin: true
+    dependencies:
+      copy-anything: 2.0.6
+      tslib: 1.14.1
     optionalDependencies:
       errno: 0.1.8
       graceful-fs: 4.2.11
       image-size: 0.5.5
+      make-dir: 2.1.0
       mime: 1.6.0
-      mkdirp: 0.5.6
-      promise: 7.3.1
-      request: 2.81.0
-      source-map: 0.5.7
+      native-request: 1.1.0
+      source-map: 0.6.1
 
   /leven@3.1.0:
     resolution: {integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==}
@@ -6470,6 +6255,15 @@ packages:
     dependencies:
       pify: 3.0.0
     dev: false
+
+  /make-dir@2.1.0:
+    resolution: {integrity: sha512-LS9X+dc8KLxXCb8dni79fLIIUA5VyZoyjSMCwTluaXA0o27cCK0bhXkpgw+sTXVpPy/lSO57ilRixqk0vDmtRA==}
+    engines: {node: '>=6'}
+    requiresBuild: true
+    dependencies:
+      pify: 4.0.1
+      semver: 5.7.2
+    optional: true
 
   /make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
@@ -6791,12 +6585,14 @@ packages:
   /mime-db@1.52.0:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
+    dev: false
 
   /mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
     dependencies:
       mime-db: 1.52.0
+    dev: false
 
   /mime@1.4.1:
     resolution: {integrity: sha512-KI1+qOZu5DcW6wayYHSzR/tXKCDC5Om4s1z2QJjDULzLcmf3DvzS7oluY4HCTrc+9FiKmWUgeNLg7W3uIQvxtQ==}
@@ -6870,6 +6666,7 @@ packages:
     requiresBuild: true
     dependencies:
       minimist: 1.2.8
+    dev: true
 
   /mri@1.2.0:
     resolution: {integrity: sha512-tzzskb3bG8LvYGFF/mDTpq3jpI6Q9wc3LEmBaghu+DdCssd1FakN7Bc0hVNmEyGq1bq3RgfkCb3cmQLpNPOroA==}
@@ -6902,6 +6699,11 @@ packages:
     resolution: {integrity: sha512-BGcqMMJuToF7i1rt+2PWSNVnWIkGCU78jBG3RxO/bZlnZPK2Cmi2QaffxGO/2RvWi9sL+FAiRiXMgsyxQ1DIDA==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+
+  /native-request@1.1.0:
+    resolution: {integrity: sha512-uZ5rQaeRn15XmpgE0xoPL8YWqcX90VtCFglYwAgkvKM5e8fog+vePLAhHxuuv/gRkrQxIeh5U3q9sMNUrENqWw==}
+    requiresBuild: true
+    optional: true
 
   /natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
@@ -6986,11 +6788,6 @@ packages:
     dependencies:
       boolbase: 1.0.0
     dev: false
-
-  /oauth-sign@0.8.2:
-    resolution: {integrity: sha512-VlF07iu3VV3+BTXj43Nmp6Irt/G7j/NgEctUS6IweH1RGhURjjCc2NWtzXFPXXWWfc7hgbXQdtiQu2LGp6MxUg==}
-    requiresBuild: true
-    optional: true
 
   /object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
@@ -7336,11 +7133,6 @@ packages:
   /pend@1.2.0:
     resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
     dev: false
-
-  /performance-now@0.2.0:
-    resolution: {integrity: sha512-YHk5ez1hmMR5LOkb9iJkLKqoBlL7WD5M8ljC75ZfzXriuBIVNuecaXuU7e+hOwyqf24Wxhh7Vxgt7Hnw9288Tg==}
-    requiresBuild: true
-    optional: true
 
   /periscopic@3.1.0:
     resolution: {integrity: sha512-vKiQ8RRtkl9P+r/+oefh25C3fhybptkHKCZSPlcXiJux2tJF55GnEj3BVn4A5gKfq9NWWXXrxkHBwVPUfH0opw==}
@@ -7994,13 +7786,6 @@ packages:
     resolution: {integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==}
     dev: false
 
-  /promise@7.3.1:
-    resolution: {integrity: sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==}
-    requiresBuild: true
-    dependencies:
-      asap: 2.0.6
-    optional: true
-
   /prompts@2.4.2:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
     engines: {node: '>= 6'}
@@ -8029,11 +7814,6 @@ packages:
       once: 1.4.0
     dev: false
 
-  /punycode@1.4.1:
-    resolution: {integrity: sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==}
-    requiresBuild: true
-    optional: true
-
   /punycode@2.3.0:
     resolution: {integrity: sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==}
     engines: {node: '>=6'}
@@ -8042,12 +7822,6 @@ packages:
   /pure-rand@6.0.3:
     resolution: {integrity: sha512-KddyFewCsO0j3+np81IQ+SweXLDnDQTs5s67BOnrYmYe/yNmUhttQyGsYzy8yUnoljGAQ9sl38YB4vH8ur7Y+w==}
     dev: true
-
-  /qs@6.4.1:
-    resolution: {integrity: sha512-LQy1Q1fcva/UsnP/6Iaa4lVeM49WiOitu2T4hZCyA/elLKu37L99qcBJk4VCCk+rdLvnMzfKyiN3SZTqdAZGSQ==}
-    engines: {node: '>=0.6'}
-    requiresBuild: true
-    optional: true
 
   /query-string@5.1.1:
     resolution: {integrity: sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==}
@@ -8242,36 +8016,6 @@ packages:
     engines: {node: '>= 10'}
     dev: false
 
-  /request@2.81.0:
-    resolution: {integrity: sha512-IZnsR7voF0miGSu29EXPRgPTuEsI/+aibNSBbN1pplrfartF5wDYGADz3iD9vmBVf2r00rckWZf8BtS5kk7Niw==}
-    engines: {node: '>= 4'}
-    deprecated: request has been deprecated, see https://github.com/request/request/issues/3142
-    requiresBuild: true
-    dependencies:
-      aws-sign2: 0.6.0
-      aws4: 1.12.0
-      caseless: 0.12.0
-      combined-stream: 1.0.8
-      extend: 3.0.2
-      forever-agent: 0.6.1
-      form-data: 2.1.4
-      har-validator: 4.2.1
-      hawk: 3.1.3
-      http-signature: 1.1.1
-      is-typedarray: 1.0.0
-      isstream: 0.1.2
-      json-stringify-safe: 5.0.1
-      mime-types: 2.1.35
-      oauth-sign: 0.8.2
-      performance-now: 0.2.0
-      qs: 6.4.1
-      safe-buffer: 5.2.1
-      stringstream: 0.0.6
-      tough-cookie: 2.3.4
-      tunnel-agent: 0.6.0
-      uuid: 3.4.0
-    optional: true
-
   /require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
@@ -8393,6 +8137,7 @@ packages:
 
   /safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+    dev: false
 
   /safe-regex-test@1.0.0:
     resolution: {integrity: sha512-JBUUzyOgEwXQY1NuPtvcj/qcBDbDmEvWufhlnXZIm75DEHp+afM1r1ujJpJsV/gSM4t59tpDyPi1sd6ZaPFfsA==}
@@ -8618,15 +8363,6 @@ packages:
       yargs: 15.4.1
     dev: true
 
-  /sntp@1.0.9:
-    resolution: {integrity: sha512-7bgVOAnPj3XjrKY577S+puCKGCRlUrcrEdsMeRXlg9Ghf5df/xNi6sONUa43WrHUd3TjJBF7O04jYoiY0FVa0A==}
-    engines: {node: '>=0.8.0'}
-    deprecated: This module moved to @hapi/sntp. Please make sure to switch over as this distribution is no longer supported and may contain bugs and critical security issues.
-    requiresBuild: true
-    dependencies:
-      hoek: 2.16.3
-    optional: true
-
   /socket.io-adapter@2.5.2:
     resolution: {integrity: sha512-87C3LO/NOMc+eMcpcxUBebGjkpMDkNBS9tf7KJqcDsmL936EChtVva71Dw2q4tQcuVC+hAUy4an2NO/sYXmwRA==}
     dependencies:
@@ -8750,12 +8486,6 @@ packages:
       source-map: 0.6.1
     dev: false
 
-  /source-map@0.5.7:
-    resolution: {integrity: sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==}
-    engines: {node: '>=0.10.0'}
-    requiresBuild: true
-    optional: true
-
   /source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
@@ -8802,23 +8532,6 @@ packages:
       console-stream: 0.1.1
       lpad-align: 1.1.2
     dev: false
-
-  /sshpk@1.17.0:
-    resolution: {integrity: sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==}
-    engines: {node: '>=0.10.0'}
-    hasBin: true
-    requiresBuild: true
-    dependencies:
-      asn1: 0.2.6
-      assert-plus: 1.0.0
-      bcrypt-pbkdf: 1.0.2
-      dashdash: 1.14.1
-      ecc-jsbn: 0.1.2
-      getpass: 0.1.7
-      jsbn: 0.1.1
-      safer-buffer: 2.1.2
-      tweetnacl: 0.14.5
-    optional: true
 
   /stable@0.1.8:
     resolution: {integrity: sha512-ji9qxRnOVfcuLDySj9qzhGSEFVobyt1kIOSkj1qZzYLzq7Tos/oUUWvotUPQLlrsidqsK6tBH89Bc9kL5zHA6w==}
@@ -8928,11 +8641,6 @@ packages:
     dependencies:
       safe-buffer: 5.2.1
     dev: false
-
-  /stringstream@0.0.6:
-    resolution: {integrity: sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA==}
-    requiresBuild: true
-    optional: true
 
   /strip-ansi@3.0.1:
     resolution: {integrity: sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==}
@@ -9401,14 +9109,6 @@ packages:
     engines: {node: '>=6'}
     dev: true
 
-  /tough-cookie@2.3.4:
-    resolution: {integrity: sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==}
-    engines: {node: '>=0.8'}
-    requiresBuild: true
-    dependencies:
-      punycode: 1.4.1
-    optional: true
-
   /trim-newlines@1.0.0:
     resolution: {integrity: sha512-Nm4cF79FhSTzrLKGDMi3I4utBtFv8qKy4sq1enftf2gMdpqI8oVQTAfySkTz5r49giVzDj88SVZXP4CeYQwjaw==}
     engines: {node: '>=0.10.0'}
@@ -9461,6 +9161,9 @@ packages:
       strip-bom: 3.0.0
     dev: true
 
+  /tslib@1.14.1:
+    resolution: {integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==}
+
   /tslib@2.6.2:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
     dev: true
@@ -9484,11 +9187,7 @@ packages:
     requiresBuild: true
     dependencies:
       safe-buffer: 5.2.1
-
-  /tweetnacl@0.14.5:
-    resolution: {integrity: sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==}
-    requiresBuild: true
-    optional: true
+    dev: false
 
   /type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -9748,6 +9447,7 @@ packages:
     deprecated: Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.
     hasBin: true
     requiresBuild: true
+    dev: false
 
   /uvu@0.5.6:
     resolution: {integrity: sha512-+g8ENReyr8YsOc6fv/NVJs2vFdHBnBNdfE49rshrTzDWOlUx4Gq7KOS2GD8eqhy2j+Ejq29+SbKH8yjkAqXqoA==}
@@ -9779,16 +9479,6 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
     dev: false
-
-  /verror@1.10.0:
-    resolution: {integrity: sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==}
-    engines: {'0': node >=0.6.0}
-    requiresBuild: true
-    dependencies:
-      assert-plus: 1.0.0
-      core-util-is: 1.0.2
-      extsprintf: 1.3.0
-    optional: true
 
   /vfile-message@2.0.4:
     resolution: {integrity: sha512-DjssxRGkMvifUOJre00juHoP9DPWuzjxKuMDrhNbk2TdaYYBNMStsNhEOt3idrtI12VQYM/1+iM0KOzXi4pxwQ==}

--- a/shared/tsconfig.base.json
+++ b/shared/tsconfig.base.json
@@ -3,7 +3,7 @@
     "noEmit": true,
     "strict": true,
     "target": "es2020",
-    "module": "es2022",
+    "module": "nodenext",
     "moduleResolution": "node",
     "allowSyntheticDefaultImports": true,
     "noUnusedLocals": true,


### PR DESCRIPTION
- move peer dependencies out of the plugin (when possible) to avoid duplicate download, and let the user freely upgrade its version
- bump compatible less version to 3
- update docs